### PR TITLE
Database Schema utils

### DIFF
--- a/utils/create_indexes.py
+++ b/utils/create_indexes.py
@@ -1,0 +1,76 @@
+from pymongo import ASCENDING, IndexModel
+
+from utils.db import get_db
+
+
+def create_indexes() -> None:
+    db = get_db()
+    if db is None:
+        raise ConnectionError("Could not connect to MongoDB")
+
+    db["users"].create_indexes(
+        [
+            IndexModel([("email", ASCENDING)], name="email_unique", unique=True),
+        ]
+    )
+
+    db["cadets"].create_indexes(
+        [
+            IndexModel([("user_id", ASCENDING)], name="user_id_unique", unique=True),
+        ]
+    )
+
+    db["events"].create_indexes(
+        [
+            IndexModel([("event_type", ASCENDING)], name="event_type"),
+            IndexModel([("created_by_user_id", ASCENDING)], name="created_by_user_id"),
+            IndexModel([("start_date", ASCENDING)], name="start_date"),
+        ]
+    )
+
+    db["event_assignments"].create_indexes(
+        [
+            IndexModel(
+                [("event_id", ASCENDING), ("cadet_id", ASCENDING)],
+                name="event_cadet_unique",
+                unique=True,
+            ),
+            IndexModel(
+                [("assigned_by_user_id", ASCENDING)], name="assigned_by_user_id"
+            ),
+        ]
+    )
+
+    db["attendance_records"].create_indexes(
+        [
+            IndexModel(
+                [("event_id", ASCENDING), ("cadet_id", ASCENDING)],
+                name="event_cadet_unique",
+                unique=True,
+            ),
+            IndexModel(
+                [("recorded_by_user_id", ASCENDING)], name="recorded_by_user_id"
+            ),
+        ]
+    )
+
+    db["waivers"].create_indexes(
+        [
+            IndexModel(
+                [("attendance_record_id", ASCENDING)],
+                name="attendance_record_id_unique",
+                unique=True,
+            ),
+            IndexModel(
+                [("submitted_by_user_id", ASCENDING)], name="submitted_by_user_id"
+            ),
+            IndexModel([("status", ASCENDING)], name="status"),
+        ]
+    )
+
+    db["waiver_approvals"].create_indexes(
+        [
+            IndexModel([("waiver_id", ASCENDING)], name="waiver_id"),
+            IndexModel([("approver_id", ASCENDING)], name="approver_id"),
+        ]
+    )

--- a/utils/db.py
+++ b/utils/db.py
@@ -1,8 +1,9 @@
 from pymongo import MongoClient
 from pymongo.collection import Collection
 from pymongo.database import Database
-from pymongo.results import InsertOneResult
 from config.settings import MONGODB_URI, MONGODB_DB
+
+from utils.create_indexes import create_indexes
 
 __client = None
 
@@ -15,6 +16,7 @@ def get_client() -> MongoClient | None:
 
     if __client is None:
         __client = MongoClient(MONGODB_URI)
+        _ensure_indexes()
 
     return __client
 
@@ -33,15 +35,6 @@ def get_collection(collection_name: str) -> Collection | None:
     return db[collection_name]
 
 
-def insert_one(collection_name: str, document: dict) -> InsertOneResult | None:
-    collection = get_collection(collection_name)
-    if collection is None:
-        return None
-    return collection.insert_one(document)
-
-
-def find_one(collection_name: str, query: dict) -> dict | None:
-    collection = get_collection(collection_name)
-    if collection is None:
-        return None
-    return collection.find_one(query)
+# we create the indexes so that we can enforce unique constraints on the fields
+def _ensure_indexes() -> None:
+    create_indexes()

--- a/utils/db_schema_crud.py
+++ b/utils/db_schema_crud.py
@@ -1,0 +1,381 @@
+from datetime import datetime, timezone
+
+from bson import ObjectId
+from pymongo.results import DeleteResult, InsertOneResult, UpdateResult
+
+from utils.db import get_collection
+
+# -- Users
+
+
+def create_user(
+    first_name: str,
+    last_name: str,
+    email: str,
+    password_hash: str,
+    roles: list[str],
+) -> InsertOneResult | None:
+    col = get_collection("users")
+    if col is None:
+        return None
+    return col.insert_one(
+        {
+            "first_name": first_name,
+            "last_name": last_name,
+            "email": email,
+            "password_hash": password_hash,
+            "roles": roles,
+            "created_at": datetime.now(timezone.utc),
+        }
+    )
+
+
+def get_user_by_id(user_id: str | ObjectId) -> dict | None:
+    col = get_collection("users")
+    if col is None:
+        return None
+    return col.find_one({"_id": ObjectId(user_id)})
+
+
+def get_user_by_email(email: str) -> dict | None:
+    col = get_collection("users")
+    if col is None:
+        return None
+    return col.find_one({"email": email})
+
+
+def update_user(user_id: str | ObjectId, updates: dict) -> UpdateResult | None:
+    col = get_collection("users")
+    if col is None:
+        return None
+    return col.update_one({"_id": ObjectId(user_id)}, {"$set": updates})
+
+
+def delete_user(user_id: str | ObjectId) -> DeleteResult | None:
+    col = get_collection("users")
+    if col is None:
+        return None
+    return col.delete_one({"_id": ObjectId(user_id)})
+
+
+# -- Cadets
+
+
+def create_cadet(user_id: str | ObjectId, rank: str) -> InsertOneResult | None:
+    col = get_collection("cadets")
+    if col is None:
+        return None
+    return col.insert_one(
+        {
+            "user_id": ObjectId(user_id),
+            "rank": rank,
+        }
+    )
+
+
+def get_cadet_by_id(cadet_id: str | ObjectId) -> dict | None:
+    col = get_collection("cadets")
+    if col is None:
+        return None
+    return col.find_one({"_id": ObjectId(cadet_id)})
+
+
+def get_cadet_by_user_id(user_id: str | ObjectId) -> dict | None:
+    col = get_collection("cadets")
+    if col is None:
+        return None
+    return col.find_one({"user_id": ObjectId(user_id)})
+
+
+def update_cadet(cadet_id: str | ObjectId, updates: dict) -> UpdateResult | None:
+    col = get_collection("cadets")
+    if col is None:
+        return None
+    return col.update_one({"_id": ObjectId(cadet_id)}, {"$set": updates})
+
+
+def delete_cadet(cadet_id: str | ObjectId) -> DeleteResult | None:
+    col = get_collection("cadets")
+    if col is None:
+        return None
+    return col.delete_one({"_id": ObjectId(cadet_id)})
+
+
+# -- Events
+
+
+def create_event(
+    event_name: str,
+    event_type: str,
+    start_date: datetime,
+    end_date: datetime,
+    created_by_user_id: str | ObjectId,
+) -> InsertOneResult | None:
+    col = get_collection("events")
+    if col is None:
+        return None
+    return col.insert_one(
+        {
+            "event_name": event_name,
+            "event_type": event_type,
+            "start_date": start_date,
+            "end_date": end_date,
+            "created_by_user_id": ObjectId(created_by_user_id),
+            "created_at": datetime.now(timezone.utc),
+        }
+    )
+
+
+def get_event_by_id(event_id: str | ObjectId) -> dict | None:
+    col = get_collection("events")
+    if col is None:
+        return None
+    return col.find_one({"_id": ObjectId(event_id)})
+
+
+def get_events_by_type(event_type: str) -> list[dict]:
+    col = get_collection("events")
+    if col is None:
+        return []
+    return list(col.find({"event_type": event_type}))
+
+
+def get_events_by_creator(user_id: str | ObjectId) -> list[dict]:
+    col = get_collection("events")
+    if col is None:
+        return []
+    return list(col.find({"created_by_user_id": ObjectId(user_id)}))
+
+
+def update_event(event_id: str | ObjectId, updates: dict) -> UpdateResult | None:
+    col = get_collection("events")
+    if col is None:
+        return None
+    return col.update_one({"_id": ObjectId(event_id)}, {"$set": updates})
+
+
+def delete_event(event_id: str | ObjectId) -> DeleteResult | None:
+    col = get_collection("events")
+    if col is None:
+        return None
+    return col.delete_one({"_id": ObjectId(event_id)})
+
+
+# -- Event Assignments
+
+
+def create_event_assignment(
+    event_id: str | ObjectId,
+    cadet_id: str | ObjectId,
+    assigned_by_user_id: str | ObjectId,
+) -> InsertOneResult | None:
+    col = get_collection("event_assignments")
+    if col is None:
+        return None
+    return col.insert_one(
+        {
+            "event_id": ObjectId(event_id),
+            "cadet_id": ObjectId(cadet_id),
+            "assigned_by_user_id": ObjectId(assigned_by_user_id),
+            "created_at": datetime.now(timezone.utc),
+        }
+    )
+
+
+def get_event_assignment_by_id(assignment_id: str | ObjectId) -> dict | None:
+    col = get_collection("event_assignments")
+    if col is None:
+        return None
+    return col.find_one({"_id": ObjectId(assignment_id)})
+
+
+def get_assignments_by_event(event_id: str | ObjectId) -> list[dict]:
+    col = get_collection("event_assignments")
+    if col is None:
+        return []
+    return list(col.find({"event_id": ObjectId(event_id)}))
+
+
+def get_assignments_by_cadet(cadet_id: str | ObjectId) -> list[dict]:
+    col = get_collection("event_assignments")
+    if col is None:
+        return []
+    return list(col.find({"cadet_id": ObjectId(cadet_id)}))
+
+
+def delete_event_assignment(assignment_id: str | ObjectId) -> DeleteResult | None:
+    col = get_collection("event_assignments")
+    if col is None:
+        return None
+    return col.delete_one({"_id": ObjectId(assignment_id)})
+
+
+# -- Attendance Records
+
+
+def create_attendance_record(
+    event_id: str | ObjectId,
+    cadet_id: str | ObjectId,
+    status: str,
+    recorded_by_user_id: str | ObjectId,
+) -> InsertOneResult | None:
+    col = get_collection("attendance_records")
+    if col is None:
+        return None
+    return col.insert_one(
+        {
+            "event_id": ObjectId(event_id),
+            "cadet_id": ObjectId(cadet_id),
+            "status": status,
+            "recorded_by_user_id": ObjectId(recorded_by_user_id),
+            "created_at": datetime.now(timezone.utc),
+        }
+    )
+
+
+def get_attendance_record_by_id(record_id: str | ObjectId) -> dict | None:
+    col = get_collection("attendance_records")
+    if col is None:
+        return None
+    return col.find_one({"_id": ObjectId(record_id)})
+
+
+def get_attendance_by_event(event_id: str | ObjectId) -> list[dict]:
+    col = get_collection("attendance_records")
+    if col is None:
+        return []
+    return list(col.find({"event_id": ObjectId(event_id)}))
+
+
+def get_attendance_by_cadet(cadet_id: str | ObjectId) -> list[dict]:
+    col = get_collection("attendance_records")
+    if col is None:
+        return []
+    return list(col.find({"cadet_id": ObjectId(cadet_id)}))
+
+
+def update_attendance_record(
+    record_id: str | ObjectId, updates: dict
+) -> UpdateResult | None:
+    col = get_collection("attendance_records")
+    if col is None:
+        return None
+    return col.update_one({"_id": ObjectId(record_id)}, {"$set": updates})
+
+
+def delete_attendance_record(record_id: str | ObjectId) -> DeleteResult | None:
+    col = get_collection("attendance_records")
+    if col is None:
+        return None
+    return col.delete_one({"_id": ObjectId(record_id)})
+
+
+# -- Waivers
+
+
+def create_waiver(
+    attendance_record_id: str | ObjectId,
+    reason: str,
+    status: str,
+    submitted_by_user_id: str | ObjectId,
+) -> InsertOneResult | None:
+    col = get_collection("waivers")
+    if col is None:
+        return None
+    return col.insert_one(
+        {
+            "attendance_record_id": ObjectId(attendance_record_id),
+            "reason": reason,
+            "status": status,
+            "submitted_by_user_id": ObjectId(submitted_by_user_id),
+            "created_at": datetime.now(timezone.utc),
+        }
+    )
+
+
+def get_waiver_by_id(waiver_id: str | ObjectId) -> dict | None:
+    col = get_collection("waivers")
+    if col is None:
+        return None
+    return col.find_one({"_id": ObjectId(waiver_id)})
+
+
+def get_waiver_by_attendance_record(
+    attendance_record_id: str | ObjectId,
+) -> dict | None:
+    col = get_collection("waivers")
+    if col is None:
+        return None
+    return col.find_one({"attendance_record_id": ObjectId(attendance_record_id)})
+
+
+def get_waivers_by_status(status: str) -> list[dict]:
+    col = get_collection("waivers")
+    if col is None:
+        return []
+    return list(col.find({"status": status}))
+
+
+def update_waiver(waiver_id: str | ObjectId, updates: dict) -> UpdateResult | None:
+    col = get_collection("waivers")
+    if col is None:
+        return None
+    return col.update_one({"_id": ObjectId(waiver_id)}, {"$set": updates})
+
+
+def delete_waiver(waiver_id: str | ObjectId) -> DeleteResult | None:
+    col = get_collection("waivers")
+    if col is None:
+        return None
+    return col.delete_one({"_id": ObjectId(waiver_id)})
+
+
+# -- Waiver Approvals
+
+
+def create_waiver_approval(
+    waiver_id: str | ObjectId,
+    approver_id: str | ObjectId,
+    decision: str,
+    comments: str,
+) -> InsertOneResult | None:
+    col = get_collection("waiver_approvals")
+    if col is None:
+        return None
+    return col.insert_one(
+        {
+            "waiver_id": ObjectId(waiver_id),
+            "approver_id": ObjectId(approver_id),
+            "decision": decision,
+            "comments": comments,
+            "created_at": datetime.now(timezone.utc),
+        }
+    )
+
+
+def get_waiver_approval_by_id(approval_id: str | ObjectId) -> dict | None:
+    col = get_collection("waiver_approvals")
+    if col is None:
+        return None
+    return col.find_one({"_id": ObjectId(approval_id)})
+
+
+def get_approvals_by_waiver(waiver_id: str | ObjectId) -> list[dict]:
+    col = get_collection("waiver_approvals")
+    if col is None:
+        return []
+    return list(col.find({"waiver_id": ObjectId(waiver_id)}))
+
+
+def get_approvals_by_approver(approver_id: str | ObjectId) -> list[dict]:
+    col = get_collection("waiver_approvals")
+    if col is None:
+        return []
+    return list(col.find({"approver_id": ObjectId(approver_id)}))
+
+
+def delete_waiver_approval(approval_id: str | ObjectId) -> DeleteResult | None:
+    col = get_collection("waiver_approvals")
+    if col is None:
+        return None
+    return col.delete_one({"_id": ObjectId(approval_id)})


### PR DESCRIPTION
enforce uniqueness in keys and provide a set of tools defining the schema since mongodb automatically sets up the collection as you input data in it rather than defining a schema beforehand like SQL. to use the tools check out db_schema_crud.py 

closes #11 

there is still more work to do in terms of connecting this with auth but it was a bit of a loaded ticket to design the whole schema at once.

this opened up ticket #67 because i have not implemented password hashing yet even though it was defined in the schema.