### PR TITLE
Add event schedule configuration page for PT and LLAB days

### DIFF
--- a/pages/6_Event_Schedule_Config.py
+++ b/pages/6_Event_Schedule_Config.py
@@ -1,12 +1,15 @@
 import streamlit as st
-from pymongo import MongoClient
 import os
+
+from utils.auth import require_role
+from utils.db import get_db
+
+require_role("admin", "flight_commander")
 
 st.title("Event Schedule Configuration")
 
 # --- Connect to DB ---
-client = MongoClient(os.getenv("MONGO_URI"))
-db = client["rollcall"]
+db = get_db()
 
 # --- Load Existing Config ---
 config = db.event_config.find_one({})


### PR DESCRIPTION
This PR adds a new Event Schedule Configuration page that allows to configure which weekdays correspond to PT and LLAB events. The configuration is stored in MongoDB and no hardcoded approach. Closes #33 
