### PR TITLE
Add unassign cadet functionality in Flight Management page

### DIFF
--- a/pages/4_Flight_Management.py
+++ b/pages/4_Flight_Management.py
@@ -6,6 +6,7 @@ from utils.db_schema_crud import (
     get_all_flights,
     delete_flight,
     assign_cadet_to_flight,
+    unassign_cadet_from_flight,
     get_user_by_id,
     get_cadet_by_id,
 )
@@ -123,6 +124,7 @@ for flight in flights:
             st.success("Cadet assigned successfully!")
             st.rerun()
 
+
     # Show Cadets in Flight
     st.write("Cadets in this Flight:")
 
@@ -131,14 +133,29 @@ for flight in flights:
     if cadets_in_flight:
         for cadet in cadets_in_flight:
             user = get_user_by_id(cadet["user_id"])
+
             if user:
-                name = (
-                    f"{user.get('first_name', '')} {user.get('last_name', '')}".strip()
-                )
+                name = f"{user.get('first_name', '')} {user.get('last_name', '')}".strip()
                 rank = cadet.get("rank", "")
-                st.write(f"- {name} ({rank})")
+
+                col1, col2 = st.columns([4, 1])
+
+                with col1:
+                    st.write(f"{name} ({rank})")
+
+                with col2:
+                    if st.button("Unassign", key=f"unassign_{cadet['_id']}"):
+                        unassign_cadet_from_flight(cadet["_id"])
+                        st.success("Cadet unassigned from flight.")
+                        st.rerun()
     else:
         st.write("No cadets assigned yet.")
+
+
+
+    
+
+
 
     # Delete Flight
     if st.button("Delete Flight", key=f"delete_{flight['_id']}"):

--- a/utils/db_schema_crud.py
+++ b/utils/db_schema_crud.py
@@ -534,3 +534,13 @@ def assign_cadet_to_flight(cadet_id: str | ObjectId, flight_id: str | ObjectId):
         {"_id": ObjectId(cadet_id)},
         {"$set": {"flight_id": ObjectId(flight_id)}},
     )
+
+def unassign_cadet_from_flight(cadet_id: str | ObjectId):
+    col = get_collection("cadets")
+    if col is None:
+        return None
+
+    return col.update_one(
+        {"_id": ObjectId(cadet_id)},
+        {"$unset": {"flight_id": ""}},
+    )


### PR DESCRIPTION
Adds an Unassign button to remove cadets from flights without deleting the flight.

Changes:
- Added unassign_cadet_from_flight() helper using MongoDB $unset
- Added Unassign button in Flight Management page UI

Closes #91
