### PR TITLE
Add edge case tests for unassign cadet functionality

### DIFF
--- a/tests/test_flight_management.py
+++ b/tests/test_flight_management.py
@@ -1,52 +1,50 @@
 import sys
 import os
-import pytest
+from unittest.mock import patch, MagicMock
+from bson import ObjectId
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from utils.db_schema_crud import unassign_cadet_from_flight
-from utils.db import get_collection
-from bson import ObjectId
 
 
-def test_unassign_cadet_from_flight():
-    cadets = get_collection("cadets")
+@patch("utils.db_schema_crud.get_collection")
+def test_unassign_cadet_from_flight(mock_get_collection):
+    # Create mock collection
+    mock_collection = MagicMock()
+    mock_get_collection.return_value = mock_collection
 
-    test_cadet = cadets.insert_one({
-        "user_id": ObjectId(),
-        "rank": "100",
-        "flight_id": ObjectId()
-    })
+    cadet_id = ObjectId()
 
-    cadet_id = test_cadet.inserted_id
+    # Call function
+    unassign_cadet_from_flight(cadet_id)
+
+    # Check if update_one was called correctly
+    mock_collection.update_one.assert_called_once_with(
+        {"_id": cadet_id},
+        {"$unset": {"flight_id": ""}},
+    )
+
+
+@patch("utils.db_schema_crud.get_collection")
+def test_unassign_cadet_without_flight(mock_get_collection):
+    mock_collection = MagicMock()
+    mock_get_collection.return_value = mock_collection
+
+    cadet_id = ObjectId()
 
     unassign_cadet_from_flight(cadet_id)
 
-    updated = cadets.find_one({"_id": cadet_id})
-
-    assert "flight_id" not in updated
+    mock_collection.update_one.assert_called_once()
 
 
-def test_unassign_cadet_without_flight():
-    cadets = get_collection("cadets")
-
-    test_cadet = cadets.insert_one({
-        "user_id": ObjectId(),
-        "rank": "200"
-    })
-
-    cadet_id = test_cadet.inserted_id
-
-    unassign_cadet_from_flight(cadet_id)
-
-    updated = cadets.find_one({"_id": cadet_id})
-
-    assert "flight_id" not in updated
+import pytest
 
 
+@patch("utils.db_schema_crud.get_collection")
+def test_unassign_invalid_id(mock_get_collection):
+    mock_collection = MagicMock()
+    mock_get_collection.return_value = mock_collection
 
-def test_unassign_invalid_id():
     with pytest.raises(Exception):
         unassign_cadet_from_flight("invalid_id")
-
-


### PR DESCRIPTION
This PR adds unit tests for the unassign cadet functionality in Flight Management.

Tests included
1) Successfully unassigning a cadet from a flight
2) Handling cadets who are already unassigned
3) Handling invalid input (ensuring proper error behavior)

How to test:
1. Activate virtual environment
2. Run: pytest
3. Expected result: all tests pass

This improves reliability by validating backend behavior and edge cases.

closes #118 