### PR TITLE
Add admin page and connect to attendance submission page

### DIFF
--- a/Home.py
+++ b/Home.py
@@ -38,27 +38,29 @@ else:
     modify_attendance = st.Page(
         "pages/10_Commander_Attendance.py", title="Modify Attendance"
     )
+    event_code_admin = st.Page(
+        "pages/11_Event_Code_Admin.py", title="Event Code Generator"
+    )
 
     if roles & {"admin", "cadre"}:
         pages = [
             dashboard,
-            attendance,
             cadets,
             flight_mgmt,
             waiver_review,
             event_sched,
             modify_attendance,
+            event_code_admin,
         ]
         if "admin" in roles:
             pages.append(user_management)
     elif "flight_commander" in roles:
-        pages = [dashboard, fc_live_view, attendance, waiver_review]
+        pages = [dashboard, fc_live_view, waiver_review, event_code_admin]
     elif "cadet" in roles:
         pages = [attendance, waivers, cadet_attendance]
     else:
         pages = []
 
-    # Every authenticated user can manage their own account.
     pages.append(account_settings)
 
     if not pages:

--- a/pages/10_Commander_Attendance.py
+++ b/pages/10_Commander_Attendance.py
@@ -100,7 +100,7 @@ edited = st.data_editor(
         ),
     },
     hide_index=True,
-    width='stretch',
+    width="stretch",
 )
 
 st.divider()

--- a/pages/11_Event_Code_Admin.py
+++ b/pages/11_Event_Code_Admin.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from datetime import date, datetime, time, timezone
+from zoneinfo import ZoneInfo, available_timezones
+
+import streamlit as st
+
+from services.event_codes import (
+    build_expires_at,
+    create_code,
+    expire_code,
+    get_active_code,
+    is_expiry_valid,
+)
+from services.events import get_all_events
+from utils.auth import get_current_user, require_role
+from utils.db_schema_crud import get_user_by_email
+
+require_role("flight_commander", "cadre", "admin")
+
+st.title("Event Code Generator")
+st.caption("Generate attendance codes for cadets to self-report.")
+
+current_user = get_current_user()
+assert current_user is not None
+
+email = str(current_user.get("email", "") or "").strip()
+user = get_user_by_email(email)
+if user is None:
+    st.error("Could not find user account.")
+    st.stop()
+assert user is not None
+
+all_events = get_all_events()
+
+if not all_events:
+    st.warning("No events found. Create events in Event Management first.")
+    st.stop()
+
+_PREFERRED = [
+    "America/New_York",
+    "America/Chicago",
+    "America/Denver",
+    "America/Los_Angeles",
+    "America/Anchorage",
+    "Pacific/Honolulu",
+    "UTC",
+]
+TZ_OPTIONS = _PREFERRED + [
+    tz for tz in sorted(available_timezones()) if tz not in _PREFERRED
+]
+
+col_event, col_tz = st.columns([2, 1])
+
+with col_event:
+    event_labels = [
+        f"{e.get('event_type', '').upper()} | {e.get('start_date', '')} | {e.get('event_name', '')}"
+        for e in all_events
+    ]
+    today = date.today()
+
+    def _date_distance(event: dict) -> int:
+        try:
+            return abs(
+                (date.fromisoformat(str(event.get("start_date", ""))) - today).days
+            )
+        except (ValueError, TypeError):
+            return 999999
+
+    default_index = min(
+        range(len(all_events)), key=lambda i: _date_distance(all_events[i])
+    )
+    selected_label = st.selectbox("Event", event_labels, index=default_index)
+    selected_event = all_events[event_labels.index(selected_label)]
+
+with col_tz:
+    tz_name = st.selectbox("Timezone", TZ_OPTIONS, index=0)
+
+col_date, col_time = st.columns(2)
+
+with col_date:
+    exp_date = st.date_input("Expiration date", value=date.today())
+
+with col_time:
+    exp_time = st.time_input("Expiration time", value=time(23, 59))
+
+expires_at = build_expires_at(exp_date, exp_time, tz_name)
+
+if st.button("Generate New Code", type="primary", use_container_width=True):
+    if not is_expiry_valid(expires_at):
+        st.error("Expiration must be in the future.")
+    else:
+        result = create_code(
+            event_id=selected_event["_id"],
+            event_type=selected_event.get("event_type", ""),
+            event_date=str(selected_event.get("start_date", "")),
+            created_by_user_id=user["_id"],
+            expires_at=expires_at,
+        )
+        if result is None:
+            st.error("Database unavailable. Could not generate code.")
+        else:
+            st.success("New code generated.")
+            st.rerun()
+
+st.divider()
+
+active_code = get_active_code(selected_event["_id"])
+
+if active_code:
+    code_str = str(active_code.get("code", ""))
+    code_expires_at = active_code.get("expires_at")
+
+    st.markdown(
+        f"""
+        <div style="
+            text-align: center;
+            padding: 2.5rem 1rem;
+            background: #0e1117;
+            border: 2px solid #2d2d3a;
+            border-radius: 1rem;
+            margin: 1rem 0;
+        ">
+            <p style="
+                color: #888;
+                font-size: 1rem;
+                margin: 0 0 0.5rem 0;
+                letter-spacing: 0.1em;
+                text-transform: uppercase;
+            ">Active Code</p>
+            <p style="
+                font-size: 7rem;
+                font-weight: 900;
+                letter-spacing: 0.35em;
+                color: #ffffff;
+                margin: 0;
+                font-family: monospace;
+                line-height: 1;
+            ">{code_str}</p>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
+
+    if isinstance(code_expires_at, datetime):
+        if code_expires_at.tzinfo is None:
+            code_expires_at = code_expires_at.replace(tzinfo=timezone.utc)
+        now = datetime.now(timezone.utc)
+        remaining_secs = (code_expires_at - now).total_seconds()
+        local_expires = code_expires_at.astimezone(ZoneInfo(tz_name))
+        if remaining_secs > 0:
+            mins = int(remaining_secs // 60)
+            secs = int(remaining_secs % 60)
+            st.caption(
+                f"Expires {local_expires.strftime('%Y-%m-%d %I:%M %p %Z')}"
+                f" ({mins}m {secs}s remaining)"
+            )
+        else:
+            st.warning("This code has expired. Generate a new one above.")
+
+    if st.button("Expire Code Now", type="secondary"):
+        if expire_code(active_code["_id"]):
+            st.success("Code expired.")
+            st.rerun()
+        else:
+            st.error("Could not expire code.")
+
+else:
+    st.info("No active code for the selected event. Use **Generate New Code** above.")

--- a/pages/1_Dashboard.py
+++ b/pages/1_Dashboard.py
@@ -5,15 +5,12 @@ from typing import Any
 
 import pandas as pd
 import streamlit as st
-import pandas as pd
 
-from services.dashboard import get_df
 from bson import ObjectId
 
 from utils.auth import get_current_user, require_role
 from utils.db import get_collection, get_db
 from utils.at_risk_email import send_at_risk_emails
-from utils.export import to_excel
 
 _DEFAULT_DAYS = 30
 _MAX_ROWS = 2000
@@ -303,7 +300,7 @@ else:
             # Keep the event_id hidden but available for selection.
             st.dataframe(
                 summary_df.drop(columns=["_event_id"]),
-                width='stretch',
+                width="stretch",
                 hide_index=True,
             )
 
@@ -353,7 +350,7 @@ else:
                     else:
                         styler = styler.applymap(_status_cell_style, subset=["Status"])
 
-                    st.dataframe(styler, width='stretch', hide_index=True)
+                    st.dataframe(styler, width="stretch", hide_index=True)
 
                 st.subheader("Legend")
                 c1, c2, c3 = st.columns(3)

--- a/pages/2_Attendance_Submission.py
+++ b/pages/2_Attendance_Submission.py
@@ -1,36 +1,24 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
-
 import streamlit as st
-from bson import ObjectId
 
+from services.attendance import is_already_checked_in
+from services.event_codes import validate_code
 from utils.auth import get_current_user, require_auth
 from utils.db_schema_crud import (
     create_attendance_record,
-    get_attendance_by_event,
+    get_attendance_by_cadet,
     get_cadet_by_user_id,
-    get_events_by_type,
     get_user_by_email,
 )
-from services.attendance import (
-    generate_attendance_password,
-    is_already_checked_in,
-    is_within_checkin_window,
-)
-from utils.db_schema_crud import get_cadet_by_user_id, get_user_by_email
-from utils.audit_log import log_checkin_attempt
-from utils.checkin_codes import issue_checkin_code, validate_checkin_code
-from services.attendance import generate_attendance_password
 
 require_auth()
-st.title("Attendance Submission Page")
+st.title("Attendance Submission")
 
 current_user = get_current_user()
 assert current_user is not None
 
-email = current_user["email"]
-user = get_user_by_email(email)
+user = get_user_by_email(str(current_user.get("email", "") or "").strip())
 if not user:
     st.error("Could not find your account.")
     st.stop()
@@ -42,109 +30,31 @@ if not cadet:
     st.stop()
 assert cadet is not None
 
-now = datetime.now(timezone.utc)
-events = get_events_by_type("pt") + get_events_by_type("lab")
-active_events = [e for e in events if is_within_checkin_window(e, now)]
+cadet_id = cadet["_id"]
 
-CODE_TTL_MINUTES = 15
+code = st.text_input("Enter event code", max_chars=6, placeholder="000000")
 
-
-def _get_current_cadet_id() -> ObjectId | None:
-    current_user = get_current_user()
-    if not current_user:
-        return None
-
-    email = str(current_user.get("email", "") or "").strip()
-    if not email:
-        return None
-
-    user_doc = get_user_by_email(email)
-    if not user_doc:
-        return None
-    cadet_doc = get_cadet_by_user_id(user_doc["_id"])
-    if not cadet_doc:
-        return None
-
-    cadet_id = cadet_doc.get("_id")
-    return cadet_id if isinstance(cadet_id, ObjectId) else None
-
-
-cadet_id = _get_current_cadet_id()
-
-# Generate password once per session
-if "password" not in st.session_state:
-    st.session_state.password = generate_attendance_password()
-    st.session_state.password_created_at = datetime.now(timezone.utc)
-    st.session_state.password_expires_at = datetime.now(timezone.utc) + timedelta(
-        minutes=CODE_TTL_MINUTES
-    )
-    issue_checkin_code(
-        code=st.session_state.password,
-        ttl_minutes=CODE_TTL_MINUTES,
-        kind="attendance_submission",
-        now=st.session_state.password_created_at,
-    )
-    st.session_state.correctPassword = False
-password = st.session_state.password
-correctPassword = st.session_state.correctPassword
-expires_at = st.session_state.get("password_expires_at")
-
-# Writes the password for testing purposes
-st.info("testing password: " + password)
-
-# Current day of the week
-weekDay = datetime.now().strftime("%A")
-# st.info(weekDay)
-
-# Default message for attendance status
-attendanceStatus = st.empty()
-if correctPassword:
-    attendanceStatus.markdown("Attendance Status: Reported")
-else:
-    attendanceStatus.markdown("Attendance Status: Needs Reported")
-
-# Password submission and checking
-answer = st.text_input("Password", type="password")
-
-if st.button("Report In"):
-    now = datetime.now(timezone.utc)
-
-    if correctPassword:
-        outcome = "duplicate"
+if st.button("Report In", type="primary"):
+    if not code.strip():
+        st.error("Please enter a code.")
     else:
-        db_outcome = validate_checkin_code(
-            code=answer,
-            kind="attendance_submission",
-            now=now,
-        )
-
-        if db_outcome in {"success", "expired_code", "invalid_code"}:
-            outcome = db_outcome
+        event_code = validate_code(code.strip())
+        if event_code is None:
+            st.error("Invalid or expired code.")
         else:
-            outcome = "invalid_code"
-
-        if outcome == "invalid_code" and isinstance(expires_at, datetime):
-            if now > expires_at:
-                outcome = "expired_code"
-
-    if cadet_id is not None:
-        log_checkin_attempt(
-            cadet_id=cadet_id,
-            outcome=outcome,
-            attempted_code=answer,
-            source="attendance_submission",
-            now=now,
-            metadata={"ttl_minutes": CODE_TTL_MINUTES},
-        )
-
-    if outcome == "success":
-        st.success("correct password")
-        st.balloons()
-        st.session_state.correctPassword = True
-        attendanceStatus.markdown("Attendance Status: Reported")
-    elif outcome == "duplicate":
-        st.info("Already reported in this session.")
-    elif outcome == "expired_code":
-        st.error("Code expired. Please refresh to get a new code.")
-    else:
-        st.error("wrong password")
+            event_id = event_code["event_id"]
+            existing = get_attendance_by_cadet(cadet_id)
+            if is_already_checked_in(str(event_id), str(cadet_id), existing):
+                st.info("You are already checked in for this event.")
+            else:
+                result = create_attendance_record(
+                    event_id=event_id,
+                    cadet_id=cadet_id,
+                    status="present",
+                    recorded_by_user_id=user["_id"],
+                )
+                if result is None:
+                    st.error("Database unavailable. Could not record attendance.")
+                else:
+                    st.success("Checked in!")
+                    st.balloons()

--- a/pages/3_Cadets.py
+++ b/pages/3_Cadets.py
@@ -179,7 +179,7 @@ def show_cadets():
         rows,
         columns=pd.Index(["No.", "First Name", "Last Name", "Email", "Rank"]),
     )
-    st.dataframe(df, hide_index=True, width='stretch')
+    st.dataframe(df, hide_index=True, width="stretch")
 
     st.divider()
 
@@ -282,11 +282,9 @@ with tab_import:
                 }
                 for c in result["created"]
             ]
-            st.dataframe(rows, width='stretch')
+            st.dataframe(rows, width="stretch")
         if result["skipped"]:
-            st.info(
-                f"Skipped {len(result['skipped'])} already-existing account(s)."
-            )
+            st.info(f"Skipped {len(result['skipped'])} already-existing account(s).")
         if result["errors"]:
             st.error(f"{len(result['errors'])} error(s):")
             for err in result["errors"]:

--- a/pages/5_Waivers.py
+++ b/pages/5_Waivers.py
@@ -186,7 +186,7 @@ def show_waivers(
         )
 
     df = pd.DataFrame(rows, columns=pd.Index(["Event", "Date", "Status"]))
-    st.dataframe(df, hide_index=True, width='stretch')
+    st.dataframe(df, hide_index=True, width="stretch")
 
     st.divider()
 

--- a/pages/8_Cadet_Attendance.py
+++ b/pages/8_Cadet_Attendance.py
@@ -136,7 +136,7 @@ def show_attendance_table(rows: list[dict]):
         table_rows,
         columns=pd.Index(["Event", "Date", "Type", "Status", "Waiver"]),
     )
-    st.dataframe(df, hide_index=True, width='stretch')
+    st.dataframe(df, hide_index=True, width="stretch")
 
     st.divider()
 

--- a/pages/8_User_Management.py
+++ b/pages/8_User_Management.py
@@ -254,7 +254,7 @@ else:
             ],
             columns=pd.Index(["Name", "Email", "Role"]),
         )
-        st.dataframe(df, hide_index=True, width='stretch')
+        st.dataframe(df, hide_index=True, width="stretch")
 
         filtered_ids = [s["id"] for s in filtered]
         if st.session_state.admin_users_selected not in filtered_ids:

--- a/services/event_codes.py
+++ b/services/event_codes.py
@@ -1,11 +1,15 @@
+from __future__ import annotations
+
 import secrets
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, time, timedelta, timezone
+from zoneinfo import ZoneInfo
 
 from bson import ObjectId
 
 from utils.db_schema_crud import (
     create_event_code,
     deactivate_event_code,
+    find_active_event_code_by_value,
     get_active_event_code,
 )
 
@@ -13,6 +17,18 @@ from utils.db_schema_crud import (
 def generate_code() -> str:
     """Generate a random 6-digit numeric code."""
     return f"{secrets.randbelow(1000000):06}"
+
+
+def build_expires_at(exp_date: date, exp_time: time, tz_name: str) -> datetime:
+    """Combine a local date and time with a named timezone and return a UTC datetime."""
+    tz = ZoneInfo(tz_name)
+    local_dt = datetime.combine(exp_date, exp_time).replace(tzinfo=tz)
+    return local_dt.astimezone(timezone.utc)
+
+
+def is_expiry_valid(expires_at: datetime) -> bool:
+    """Return True if expires_at is strictly in the future (UTC)."""
+    return expires_at > datetime.now(timezone.utc)
 
 
 def create_code(
@@ -49,6 +65,10 @@ def expire_code(code_id: str | ObjectId) -> bool:
     """Manually deactivate a code. Returns True on success."""
     result = deactivate_event_code(code_id)
     return result is not None and result.modified_count == 1
+
+
+def validate_code(code: str) -> dict | None:
+    return find_active_event_code_by_value(code)
 
 
 def expires_at_from_preset(preset: str) -> datetime:

--- a/tests/test_attendance_submission.py
+++ b/tests/test_attendance_submission.py
@@ -105,9 +105,7 @@ def _go_to_attendance(browser):
         "nav.2",
         browser,
         10,
-        lambda d: (
-            "Attendance Submission Page" in d.find_element(By.TAG_NAME, "body").text
-        ),
+        lambda d: "Attendance Submission" in d.find_element(By.TAG_NAME, "body").text,
         "couldn't verify being on the attendance page",
     )
 
@@ -242,251 +240,171 @@ def test_move_to_attendance_submission_page(browser):
 
 
 # Test 7
-def test_check_for_attendance_password_and_box(browser):
+def test_check_for_event_code_input(browser):
     _go_to_attendance(browser)
     _wait(
-        "Test 7.6",
+        "Test 7.1",
         browser,
         10,
-        lambda d: "Password" in d.find_element(By.TAG_NAME, "body").text,
-        "couldn't find password label",
+        lambda d: "Enter event code" in d.find_element(By.TAG_NAME, "body").text,
+        "couldn't find event code label",
     )
     _wait(
-        "Test 7.7",
+        "Test 7.2",
         browser,
         10,
-        lambda d: d.find_element(By.CSS_SELECTOR, "input[aria-label='Password']"),
-        "couldn't find password text input",
+        lambda d: d.find_element(
+            By.CSS_SELECTOR, "input[aria-label='Enter event code']"
+        ),
+        "couldn't find event code text input",
     )
 
 
 # Test 8
-def test_check_for_attendance_status(browser):
+def test_check_for_report_in_button(browser):
     _go_to_attendance(browser)
     _wait(
         "Test 8.1",
         browser,
         10,
-        lambda d: (
-            "Attendance Status: Needs Reported"
-            in d.find_element(By.TAG_NAME, "body").text
+        lambda d: d.find_element(
+            By.XPATH, "//button[.//*[contains(text(), 'Report In')]]"
         ),
-        "couldn't find the attendance needs reported text",
+        "couldn't find the Report In button",
     )
 
 
 # Test 9
-def test_check_for_report_in_button(browser):
-    _go_to_attendance(browser)
-    _wait(
-        "Test 9.6",
-        browser,
-        10,
-        lambda d: d.find_element(By.CSS_SELECTOR, "button[kind='secondary']"),
-        "couldn't find the report attendance button",
-    )
-
-
-# Test 10
-def test_attendance_status_after_button_push_without_password(browser):
+def test_empty_code_shows_error(browser):
     _go_to_attendance(browser)
     button = _wait(
-        "Test 10.6",
+        "Test 9.1",
         browser,
         10,
         lambda d: d.find_element(
             By.XPATH, "//button[.//*[contains(text(), 'Report In')]]"
         ),
-        "couldn't find the report attendance button",
+        "couldn't find the Report In button",
     )
     sleep(1)
     button.click()
     _wait(
-        "Test 10.7",
+        "Test 9.2",
         browser,
         10,
-        lambda d: (
-            "Attendance Status: Needs Reported"
-            in d.find_element(By.TAG_NAME, "body").text
-        ),
-        "couldn't find the attendance status: needs reported text",
+        lambda d: "Please enter a code" in d.find_element(By.TAG_NAME, "body").text,
+        "couldn't find empty-code error message",
     )
 
 
-# Test 11
-def test_password_works_and_changes_status(browser):
-    _login(browser, "cadet1")
-
-    # Navigate to Account Settings via the sidebar nav link
-    _wait(
-        "Test 11.0",
+# Test 10
+def test_invalid_code_shows_error(browser):
+    _go_to_attendance(browser)
+    code_input = _wait(
+        "Test 10.1",
         browser,
         10,
         lambda d: d.find_element(
-            By.CSS_SELECTOR, "a[href='http://localhost:8501/Account_Settings']"
+            By.CSS_SELECTOR, "input[aria-label='Enter event code']"
         ),
-        "couldn't find Account Settings nav link",
-    ).click()
-    _wait(
-        "Test 11.1",
-        browser,
-        10,
-        lambda d: "Account Settings" in d.find_element(By.TAG_NAME, "body").text,
-        "couldn't load Account Settings page",
+        "couldn't find event code input",
     )
+    code_input.send_keys("000000")
     _wait(
-        "Test 11.2",
-        browser,
-        10,
-        lambda d: d.find_element(
-            By.CSS_SELECTOR, "input[aria-label='Current Password']"
-        ),
-        "couldn't find Current Password field",
-    ).send_keys("password")
-    _wait(
-        "Test 11.3",
-        browser,
-        10,
-        lambda d: d.find_element(By.CSS_SELECTOR, "input[aria-label='New Password']"),
-        "couldn't find New Password field",
-    ).send_keys("newpassword1")
-    _wait(
-        "Test 11.4",
-        browser,
-        10,
-        lambda d: d.find_element(
-            By.CSS_SELECTOR, "input[aria-label='Confirm New Password']"
-        ),
-        "couldn't find Confirm New Password field",
-    ).send_keys("newpassword1")
-    _wait(
-        "Test 11.5",
-        browser,
-        10,
-        lambda d: d.find_element(
-            By.XPATH, "//button[.//*[contains(text(), 'Update Password')]]"
-        ),
-        "couldn't find Update Password button",
-    ).click()
-    _wait(
-        "Test 11.6",
-        browser,
-        10,
-        lambda d: (
-            "Password updated successfully" in d.find_element(By.TAG_NAME, "body").text
-        ),
-        "password change did not succeed",
-    )
-
-    # Navigate to attendance via nav link and check in with the hint code
-    _wait(
-        "Test 11.7",
-        browser,
-        10,
-        lambda d: d.find_element(By.CSS_SELECTOR, "a[href='http://localhost:8501/']"),
-        "couldn't find Attendance nav link",
-    ).click()
-    _wait(
-        "Test 11.8",
-        browser,
-        10,
-        lambda d: (
-            "Attendance Submission Page" in d.find_element(By.TAG_NAME, "body").text
-        ),
-        "couldn't load Attendance Submission page",
-    )
-    passwordbox = _wait(
-        "Test 11.9",
-        browser,
-        10,
-        lambda d: d.find_element(By.CSS_SELECTOR, "input[aria-label='Password']"),
-        "couldn't find the password box",
-    )
-    hint = _wait(
-        "Test 11.10",
-        browser,
-        10,
-        lambda d: d.find_element(By.XPATH, "//p[contains(text(), 'testing')]"),
-        "couldn't find the testing password hint",
-    )
-    passwordbox.send_keys(hint.text[-6:])
-    _wait(
-        "Test 11.11",
+        "Test 10.2",
         browser,
         10,
         lambda d: d.find_element(
             By.XPATH, "//button[.//*[contains(text(), 'Report In')]]"
         ),
-        "couldn't find the report attendance button",
+        "couldn't find the Report In button",
     ).click()
     _wait(
-        "Test 11.12",
+        "Test 10.3",
         browser,
         10,
-        lambda d: (
-            "Attendance Status: Reported" in d.find_element(By.TAG_NAME, "body").text
-            or "already checked in" in d.find_element(By.TAG_NAME, "body").text
-        ),
-        "couldn't find reported status or already-checked-in message",
+        lambda d: "Invalid or expired code" in d.find_element(By.TAG_NAME, "body").text,
+        "couldn't find invalid code error message",
     )
 
-    # Teardown: reset password back to original so the test is repeatable
-    _wait(
-        "Test 11.13",
-        browser,
-        10,
-        lambda d: d.find_element(
-            By.CSS_SELECTOR, "a[href='http://localhost:8501/Account_Settings']"
-        ),
-        "couldn't find Account Settings nav link for teardown",
-    ).click()
-    _wait(
-        "Test 11.14",
-        browser,
-        10,
-        lambda d: "Account Settings" in d.find_element(By.TAG_NAME, "body").text,
-        "couldn't load Account Settings page for teardown",
-    )
-    _wait(
-        "Test 11.15",
-        browser,
-        10,
-        lambda d: d.find_element(
-            By.CSS_SELECTOR, "input[aria-label='Current Password']"
-        ),
-        "couldn't find Current Password field for teardown",
-    ).send_keys("newpassword1")
-    _wait(
-        "Test 11.16",
-        browser,
-        10,
-        lambda d: d.find_element(By.CSS_SELECTOR, "input[aria-label='New Password']"),
-        "couldn't find New Password field for teardown",
-    ).send_keys("password")
-    _wait(
-        "Test 11.17",
-        browser,
-        10,
-        lambda d: d.find_element(
-            By.CSS_SELECTOR, "input[aria-label='Confirm New Password']"
-        ),
-        "couldn't find Confirm New Password field for teardown",
-    ).send_keys("password")
-    _wait(
-        "Test 11.18",
-        browser,
-        10,
-        lambda d: d.find_element(
-            By.XPATH, "//button[.//*[contains(text(), 'Update Password')]]"
-        ),
-        "couldn't find Update Password button for teardown",
-    ).click()
-    _wait(
-        "Test 11.19",
-        browser,
-        10,
-        lambda d: (
-            "Password updated successfully" in d.find_element(By.TAG_NAME, "body").text
-        ),
-        "password teardown did not succeed",
-    )
+
+# Test 11
+def test_checked_in_success_with_valid_code(browser):
+    from pymongo import MongoClient
+    from config.settings import MONGODB_URI, MONGODB_DB
+    from datetime import datetime, timedelta, timezone
+    from bson import ObjectId
+
+    try:
+        client = MongoClient(MONGODB_URI, serverSelectionTimeoutMS=3000)
+        client.server_info()
+    except Exception:
+        pytest.skip("MongoDB not reachable")
+
+    db = client[MONGODB_DB]
+    event_id = ObjectId()
+    code_doc = {
+        "code": "999888",
+        "event_id": event_id,
+        "event_type": "pt",
+        "event_date": "2026-04-12",
+        "created_by_user_id": ObjectId(),
+        "created_at": datetime.now(timezone.utc),
+        "expires_at": datetime.now(timezone.utc) + timedelta(hours=1),
+        "active": True,
+    }
+    inserted = db["event_codes"].insert_one(code_doc)
+
+    try:
+        _login(browser, "cadet1")
+        _wait(
+            "Test 11.1",
+            browser,
+            10,
+            lambda d: d.find_element(
+                By.CSS_SELECTOR, "a[href='http://localhost:8501/']"
+            ),
+            "couldn't find Attendance nav link",
+        ).click()
+        _wait(
+            "Test 11.2",
+            browser,
+            10,
+            lambda d: (
+                "Attendance Submission" in d.find_element(By.TAG_NAME, "body").text
+            ),
+            "couldn't load Attendance Submission page",
+        )
+        code_input = _wait(
+            "Test 11.3",
+            browser,
+            10,
+            lambda d: d.find_element(
+                By.CSS_SELECTOR, "input[aria-label='Enter event code']"
+            ),
+            "couldn't find event code input",
+        )
+        code_input.send_keys("999888")
+        _wait(
+            "Test 11.4",
+            browser,
+            10,
+            lambda d: d.find_element(
+                By.XPATH, "//button[.//*[contains(text(), 'Report In')]]"
+            ),
+            "couldn't find Report In button",
+        ).click()
+        _wait(
+            "Test 11.5",
+            browser,
+            10,
+            lambda d: (
+                "Checked in" in d.find_element(By.TAG_NAME, "body").text
+                or "already checked in" in d.find_element(By.TAG_NAME, "body").text
+            ),
+            "couldn't find checked-in confirmation",
+        )
+    finally:
+        db["event_codes"].delete_one({"_id": inserted.inserted_id})
+        db["attendance_records"].delete_many({"event_id": event_id})
+        client.close()

--- a/tests/test_event_code_flight.py
+++ b/tests/test_event_code_flight.py
@@ -1,0 +1,369 @@
+from __future__ import annotations
+
+from datetime import date, datetime, time, timedelta, timezone
+
+from bson import ObjectId
+
+import services.event_codes as event_codes_svc
+import utils.db_schema_crud as crud
+from services.event_codes import build_expires_at, is_expiry_valid
+
+
+class _FakeInsertResult:
+    def __init__(self):
+        self.inserted_id = ObjectId()
+
+
+class _FakeCollection:
+    def __init__(self):
+        self._docs: list[dict] = []
+        self.update_many_calls: list[dict] = []
+
+    def update_many(self, filter: dict, update: dict):
+        self.update_many_calls.append({"filter": filter, "update": update})
+        for doc in self._docs:
+            if all(doc.get(k) == v for k, v in filter.items()):
+                for field, val in update.get("$set", {}).items():
+                    doc[field] = val
+
+    def insert_one(self, doc: dict):
+        self._docs.append(doc)
+        return _FakeInsertResult()
+
+    def find_one(self, filter: dict):
+        now_check = filter.get("expires_at", {})
+        gt_val = now_check.get("$gt") if isinstance(now_check, dict) else None
+
+        for doc in self._docs:
+            match = True
+            for k, v in filter.items():
+                if k == "expires_at":
+                    continue
+                if doc.get(k) != v:
+                    match = False
+                    break
+            if match and gt_val is not None:
+                exp = doc.get("expires_at")
+                if exp is None or exp <= gt_val:
+                    match = False
+            if match:
+                return doc
+        return None
+
+
+def test_create_event_code_inserts_doc(monkeypatch):
+    col = _FakeCollection()
+    monkeypatch.setattr(crud, "get_collection", lambda name: col)
+
+    event_id = ObjectId()
+    expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
+
+    crud.create_event_code(
+        code="123456",
+        event_id=event_id,
+        event_type="pt",
+        event_date="2026-04-12",
+        created_by_user_id=ObjectId(),
+        expires_at=expires_at,
+    )
+
+    assert len(col._docs) == 1
+    doc = col._docs[0]
+    assert doc["code"] == "123456"
+    assert doc["event_id"] == ObjectId(event_id)
+    assert doc["active"] is True
+
+
+def test_create_event_code_no_flight_id_in_doc(monkeypatch):
+    col = _FakeCollection()
+    monkeypatch.setattr(crud, "get_collection", lambda name: col)
+
+    crud.create_event_code(
+        code="654321",
+        event_id=ObjectId(),
+        event_type="lab",
+        event_date="2026-04-12",
+        created_by_user_id=ObjectId(),
+        expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+    )
+
+    assert "flight_id" not in col._docs[0]
+
+
+def test_create_event_code_deactivates_all_existing_active_codes(monkeypatch):
+    col = _FakeCollection()
+    event_id = ObjectId()
+
+    col._docs.extend(
+        [
+            {"event_id": ObjectId(event_id), "active": True, "code": "000001"},
+            {"event_id": ObjectId(event_id), "active": True, "code": "000002"},
+        ]
+    )
+
+    monkeypatch.setattr(crud, "get_collection", lambda name: col)
+
+    crud.create_event_code(
+        code="111111",
+        event_id=event_id,
+        event_type="pt",
+        event_date="2026-04-12",
+        created_by_user_id=ObjectId(),
+        expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+    )
+
+    assert col._docs[0]["active"] is False
+    assert col._docs[1]["active"] is False
+    assert col._docs[2]["active"] is True
+    assert col._docs[2]["code"] == "111111"
+
+
+def test_create_event_code_update_many_targets_event_id(monkeypatch):
+    col = _FakeCollection()
+    event_id = ObjectId()
+    monkeypatch.setattr(crud, "get_collection", lambda name: col)
+
+    crud.create_event_code(
+        code="999999",
+        event_id=event_id,
+        event_type="pt",
+        event_date="2026-04-12",
+        created_by_user_id=ObjectId(),
+        expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+    )
+
+    assert len(col.update_many_calls) == 1
+    f = col.update_many_calls[0]["filter"]
+    assert f["event_id"] == ObjectId(event_id)
+    assert f["active"] is True
+    assert "flight_id" not in f
+
+
+def test_get_active_event_code_returns_active_unexpired(monkeypatch):
+    col = _FakeCollection()
+    event_id = ObjectId()
+    now = datetime.now(timezone.utc)
+
+    col._docs.append(
+        {
+            "event_id": ObjectId(event_id),
+            "active": True,
+            "expires_at": now + timedelta(hours=1),
+            "code": "123456",
+        }
+    )
+    monkeypatch.setattr(crud, "get_collection", lambda name: col)
+
+    result = crud.get_active_event_code(event_id)
+    assert result is not None
+    assert result["code"] == "123456"
+
+
+def test_get_active_event_code_returns_none_when_expired(monkeypatch):
+    col = _FakeCollection()
+    event_id = ObjectId()
+    now = datetime.now(timezone.utc)
+
+    col._docs.append(
+        {
+            "event_id": ObjectId(event_id),
+            "active": True,
+            "expires_at": now - timedelta(minutes=1),
+            "code": "111111",
+        }
+    )
+    monkeypatch.setattr(crud, "get_collection", lambda name: col)
+
+    result = crud.get_active_event_code(event_id)
+    assert result is None
+
+
+def test_get_active_event_code_returns_none_when_inactive(monkeypatch):
+    col = _FakeCollection()
+    event_id = ObjectId()
+    now = datetime.now(timezone.utc)
+
+    col._docs.append(
+        {
+            "event_id": ObjectId(event_id),
+            "active": False,
+            "expires_at": now + timedelta(hours=1),
+            "code": "222222",
+        }
+    )
+    monkeypatch.setattr(crud, "get_collection", lambda name: col)
+
+    result = crud.get_active_event_code(event_id)
+    assert result is None
+
+
+def test_get_active_event_code_returns_none_for_different_event(monkeypatch):
+    col = _FakeCollection()
+    event_a = ObjectId()
+    event_b = ObjectId()
+    now = datetime.now(timezone.utc)
+
+    col._docs.append(
+        {
+            "event_id": ObjectId(event_a),
+            "active": True,
+            "expires_at": now + timedelta(hours=1),
+            "code": "333333",
+        }
+    )
+    monkeypatch.setattr(crud, "get_collection", lambda name: col)
+
+    result = crud.get_active_event_code(event_b)
+    assert result is None
+
+
+def test_service_create_code_returns_code_and_expiry(monkeypatch):
+    expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
+
+    monkeypatch.setattr(
+        event_codes_svc, "create_event_code", lambda **kw: _FakeInsertResult()
+    )
+
+    result = event_codes_svc.create_code(
+        event_id=ObjectId(),
+        event_type="pt",
+        event_date="2026-04-12",
+        created_by_user_id=ObjectId(),
+        expires_at=expires_at,
+    )
+
+    assert result is not None
+    assert len(result["code"]) == 6
+    assert result["code"].isdigit()
+    assert result["expires_at"] == expires_at
+
+
+def test_service_create_code_returns_none_on_db_failure(monkeypatch):
+    monkeypatch.setattr(event_codes_svc, "create_event_code", lambda **kw: None)
+
+    result = event_codes_svc.create_code(
+        event_id=ObjectId(),
+        event_type="pt",
+        event_date="2026-04-12",
+        created_by_user_id=ObjectId(),
+        expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+    )
+    assert result is None
+
+
+def test_service_get_active_code_delegates_to_db(monkeypatch):
+    expected = {"code": "777777", "active": True}
+    monkeypatch.setattr(event_codes_svc, "get_active_event_code", lambda eid: expected)
+
+    result = event_codes_svc.get_active_code(ObjectId())
+    assert result == expected
+
+
+def test_service_get_active_code_returns_none_when_no_active(monkeypatch):
+    monkeypatch.setattr(event_codes_svc, "get_active_event_code", lambda eid: None)
+
+    result = event_codes_svc.get_active_code(ObjectId())
+    assert result is None
+
+
+def test_build_expires_at_returns_utc():
+    result = build_expires_at(date(2026, 4, 12), time(16, 0), "America/New_York")
+    assert result.tzinfo == timezone.utc
+
+
+def test_build_expires_at_converts_eastern_to_utc():
+    result = build_expires_at(date(2026, 4, 12), time(16, 0), "America/New_York")
+    assert result.hour == 20
+    assert result.minute == 0
+
+
+def test_build_expires_at_utc_passthrough():
+    result = build_expires_at(date(2026, 4, 12), time(20, 0), "UTC")
+    assert result.hour == 20
+    assert result.minute == 0
+
+
+def test_build_expires_at_preserves_date():
+    result = build_expires_at(date(2026, 6, 15), time(9, 30), "UTC")
+    assert result.year == 2026
+    assert result.month == 6
+    assert result.day == 15
+
+
+def test_is_expiry_valid_future_returns_true():
+    assert is_expiry_valid(datetime.now(timezone.utc) + timedelta(minutes=5)) is True
+
+
+def test_is_expiry_valid_past_returns_false():
+    assert is_expiry_valid(datetime.now(timezone.utc) - timedelta(seconds=1)) is False
+
+
+def test_is_expiry_valid_now_returns_false():
+    assert is_expiry_valid(datetime.now(timezone.utc)) is False
+
+
+def test_validate_code_returns_doc_for_valid_code(monkeypatch):
+    now = datetime.now(timezone.utc)
+    expected = {
+        "code": "123456",
+        "active": True,
+        "expires_at": now + timedelta(hours=1),
+        "event_id": ObjectId(),
+    }
+
+    monkeypatch.setattr(
+        event_codes_svc,
+        "find_active_event_code_by_value",
+        lambda code: expected if code == "123456" else None,
+    )
+
+    assert event_codes_svc.validate_code("123456") == expected
+
+
+def test_validate_code_returns_none_for_wrong_code(monkeypatch):
+    monkeypatch.setattr(
+        event_codes_svc, "find_active_event_code_by_value", lambda code: None
+    )
+
+    assert event_codes_svc.validate_code("000000") is None
+
+
+def test_find_active_event_code_by_value_matches(monkeypatch):
+    col = _FakeCollection()
+    now = datetime.now(timezone.utc)
+    col._docs.append(
+        {
+            "code": "555555",
+            "active": True,
+            "expires_at": now + timedelta(hours=1),
+            "event_id": ObjectId(),
+        }
+    )
+    monkeypatch.setattr(crud, "get_collection", lambda name: col)
+
+    result = crud.find_active_event_code_by_value("555555")
+    assert result is not None
+    assert result["code"] == "555555"
+
+
+def test_find_active_event_code_by_value_no_match(monkeypatch):
+    col = _FakeCollection()
+    monkeypatch.setattr(crud, "get_collection", lambda name: col)
+
+    assert crud.find_active_event_code_by_value("999999") is None
+
+
+def test_find_active_event_code_by_value_expired_returns_none(monkeypatch):
+    col = _FakeCollection()
+    now = datetime.now(timezone.utc)
+    col._docs.append(
+        {
+            "code": "111111",
+            "active": True,
+            "expires_at": now - timedelta(minutes=1),
+            "event_id": ObjectId(),
+        }
+    )
+    monkeypatch.setattr(crud, "get_collection", lambda name: col)
+
+    assert crud.find_active_event_code_by_value("111111") is None

--- a/utils/db_schema_crud.py
+++ b/utils/db_schema_crud.py
@@ -621,6 +621,20 @@ def get_event_codes_by_event(event_id: str | ObjectId) -> list[dict]:
     return list(col.find({"event_id": ObjectId(event_id)}).sort("created_at", -1))
 
 
+def find_active_event_code_by_value(code: str) -> dict | None:
+    col = get_collection("event_codes")
+    if col is None:
+        return None
+    now = datetime.now(timezone.utc)
+    return col.find_one(
+        {
+            "code": code,
+            "active": True,
+            "expires_at": {"$gt": now},
+        }
+    )
+
+
 def assign_cadet_to_flight(cadet_id: str | ObjectId, flight_id: str | ObjectId):
     col = get_collection("cadets")
     if col is None:


### PR DESCRIPTION
closes #38, closes #94

new page for flight commanders and cadre to generate a 6-digit numeric attendance code for a selected event. Displays the active code in large text for projection. Supports configurable expiration via a local date/time picker with timezone selection (stored as UTC). Includes a manual "Expire Code Now" button. Defaults to the event closest to today's date. 

cadets enter the active code, which is validated against the event_codes collection. Duplicate check-ins are blocked. A present attendance record is written to MongoDB on success.