### PR TITLE
Fixes

### DIFF
--- a/Home.py
+++ b/Home.py
@@ -98,6 +98,12 @@ else:
 
     with st.sidebar:
         if st.button("Logout", key="logout_btn"):
+            auth = st.session_state.get("authenticator")
+            if auth is not None:
+                try:
+                    auth.cookie_controller.delete_cookie()
+                except Exception:
+                    pass
             for key in [
                 "authentication_status",
                 "username",
@@ -111,6 +117,7 @@ else:
             ]:
                 st.session_state.pop(key, None)
             st.session_state["_logged_out"] = True
-            st.rerun()
+            st.session_state["logout"] = True
+            st.switch_page(login)
 
 pg.run()

--- a/Home.py
+++ b/Home.py
@@ -1,9 +1,8 @@
 import streamlit as st
-from utils.auth import ensure_authenticator, get_current_user, restore_session
+from utils.auth import get_current_user, restore_session
 
 st.set_page_config(page_title="RollCall", page_icon="🪖", layout="wide")
 st.logo("static/logo.svg", size="large")
-st.image("static/logo.svg", width=300)
 
 
 restore_session()
@@ -21,15 +20,13 @@ else:
     attendance = st.Page("pages/2_Attendance_Submission.py", title="Attendance")
     cadets = st.Page("pages/3_Cadets.py", title="Cadets")
     flight_mgmt = st.Page("pages/4_Flight_Management.py", title="Flight Management")
-    waivers = st.Page("pages/5_Waivers.py", title="Waivers")
+    waivers = st.Page("pages/5_Waivers.py", title="My Waivers")
     waiver_review = st.Page("pages/6_Waiver_Review.py", title="Waiver Review")
     event_sched = st.Page("pages/6_Event_Management_CRUD.py", title="Event Management")
     fc_live_view = st.Page(
-        "pages/7_Flight_Commander_Live_View.py", title="Flight Commander Live View"
+        "pages/7_Flight_Commander_Live_View.py", title="Live Check-In View"
     )
-    cadet_attendance = st.Page(
-        "pages/8_Cadet_Attendance.py", title="Cadet Attendance View"
-    )
+    cadet_attendance = st.Page("pages/8_Cadet_Attendance.py", title="My Attendance")
     user_management = st.Page(
         "pages/8_User_Management.py",
         title="User Management",
@@ -46,24 +43,22 @@ else:
         "pages/11_Event_Code_Admin.py", title="Event Code Generator"
     )
 
-    # Use session state to save the current role then use the dropdown 
-    # separatly to change the shown role
-
-    # Allows viewing of all roles in the admin page
     if "view_role" not in st.session_state:
         st.session_state.view_role = roles
 
-    # Dropdown for admin page that toggles role views
+    _ROLE_LABELS = {
+        "admin": "Admin",
+        "cadre": "Cadre",
+        "flight_commander": "Flight Commander",
+        "cadet": "Cadet",
+    }
     if "admin" in roles:
-        choice = st.sidebar.selectbox("Select Role", ["admin", "cadre", "flight commander", "cadet"])
-        if choice == "admin":
-            st.session_state.view_role = {"admin"}
-        elif choice == "cadre":
-            st.session_state.view_role = {"cadre"}
-        elif choice == "flight commander":
-            st.session_state.view_role = {"flight commander"}
-        elif choice == "cadet":
-            st.session_state.view_role = {"cadet"}
+        choice = st.sidebar.selectbox(
+            "View as",
+            ["admin", "cadre", "flight_commander", "cadet"],
+            format_func=lambda r: _ROLE_LABELS.get(r, r),
+        )
+        st.session_state.view_role = {choice}
 
     if st.session_state.view_role & {"admin", "cadre"}:
         pages = [
@@ -78,9 +73,16 @@ else:
         ]
         if "admin" in st.session_state.view_role:
             pages.append(user_management)
-    elif "flight_commander" in roles:
-        pages = [dashboard, fc_live_view, attendance, waiver_review, at_risk_report, event_code_admin]
-    elif "cadet" in roles:
+    elif "flight_commander" in st.session_state.view_role:
+        pages = [
+            dashboard,
+            fc_live_view,
+            attendance,
+            waiver_review,
+            at_risk_report,
+            event_code_admin,
+        ]
+    elif "cadet" in st.session_state.view_role:
         pages = [attendance, waivers, cadet_attendance]
     else:
         pages = []
@@ -92,11 +94,21 @@ else:
 
     pg = st.navigation(pages)
 
-    if "authenticator" not in st.session_state:
-        ensure_authenticator()
-    authenticator = st.session_state.get("authenticator")
-    if authenticator:
-        with st.sidebar:
-            authenticator.logout("Logout", location="sidebar")
+    with st.sidebar:
+        if st.button("Logout", key="logout_btn"):
+            for key in [
+                "authentication_status",
+                "username",
+                "name",
+                "email",
+                "roles",
+                "_raw_users",
+                "logout",
+                "view_role",
+                "authenticator",
+            ]:
+                st.session_state.pop(key, None)
+            st.session_state["_logged_out"] = True
+            st.rerun()
 
 pg.run()

--- a/Home.py
+++ b/Home.py
@@ -17,8 +17,10 @@ else:
     roles = set(user["roles"])
 
     dashboard = st.Page("pages/1_Dashboard.py", title="Dashboard")
-    attendance = st.Page("pages/2_Attendance_Submission.py", title="Attendance")
-    cadets = st.Page("pages/3_Cadets.py", title="Cadets")
+    attendance = st.Page(
+        "pages/2_Attendance_Submission.py", title="Attendance Submission"
+    )
+    cadets = st.Page("pages/3_Cadets.py", title="Cadet Management")
     flight_mgmt = st.Page("pages/4_Flight_Management.py", title="Flight Management")
     waivers = st.Page("pages/5_Waivers.py", title="My Waivers")
     waiver_review = st.Page("pages/6_Waiver_Review.py", title="Waiver Review")

--- a/pages/0_Login.py
+++ b/pages/0_Login.py
@@ -1,8 +1,6 @@
 import streamlit as st
 from utils.auth import init_auth, get_current_user
 
-st.set_page_config(page_title="Login: RollCall", page_icon="🪖")
-
 authenticator = init_auth()
 
 if st.session_state.get("authentication_status") is False:

--- a/pages/10_Commander_Attendance.py
+++ b/pages/10_Commander_Attendance.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any
 
 import pandas as pd
 import streamlit as st
 
 from services.commander_attendance import build_commander_roster, compute_upserts
-from services.events import get_all_events
+from services.events import closest_event_index, get_all_events
 from utils.auth import get_current_user, require_role
 from utils.db_schema_crud import (
     create_attendance_record,
@@ -44,12 +45,20 @@ if not all_events:
 def _event_label(event: dict[str, Any]) -> str:
     name = str(event.get("event_name", "Event")).strip() or "Event"
     start = event.get("start_date")
-    date_str = start[:10] if isinstance(start, str) else ""
+    if isinstance(start, datetime):
+        date_str = start.date().isoformat()
+    elif isinstance(start, str):
+        date_str = start[:10]
+    else:
+        date_str = ""
     return f"{name} ({date_str})" if date_str else name
 
 
 selected_event = st.selectbox(
-    "Select event", options=all_events, format_func=_event_label
+    "Select event",
+    options=all_events,
+    format_func=_event_label,
+    index=closest_event_index(all_events),
 )
 if selected_event is None:
     st.stop()
@@ -100,7 +109,7 @@ edited = st.data_editor(
         ),
     },
     hide_index=True,
-    width="stretch",
+    use_container_width=True,
 )
 
 st.divider()

--- a/pages/10_Commander_Attendance.py
+++ b/pages/10_Commander_Attendance.py
@@ -109,7 +109,7 @@ edited = st.data_editor(
         ),
     },
     hide_index=True,
-    use_container_width=True,
+    width="stretch",
 )
 
 st.divider()

--- a/pages/11_At_Risk_Cadets.py
+++ b/pages/11_At_Risk_Cadets.py
@@ -15,9 +15,6 @@ df = get_df()
 if isinstance(df, str):
     st.warning("No cadets found.")
 elif isinstance(df, pd.DataFrame):
-    st.dataframe(df, hide_index=True, use_container_width=True)
-
-    st.divider()
     col1, col2, col3, spacer = st.columns([2, 2, 4, 8])
     col1.download_button(
         "Export CSV",
@@ -39,3 +36,6 @@ elif isinstance(df, pd.DataFrame):
             st.success(f"Emails sent to {sent} recipient(s).")
         else:
             st.warning(f"Sent: {sent}; Failed: {failed}.")
+
+    st.divider()
+    st.dataframe(df, hide_index=True, width="stretch")

--- a/pages/11_At_Risk_Cadets.py
+++ b/pages/11_At_Risk_Cadets.py
@@ -15,6 +15,9 @@ df = get_df()
 if isinstance(df, str):
     st.warning("No cadets found.")
 elif isinstance(df, pd.DataFrame):
+    st.dataframe(df, hide_index=True, use_container_width=True)
+
+    st.divider()
     col1, col2, col3, spacer = st.columns([2, 2, 4, 8])
     col1.download_button(
         "Export CSV",
@@ -36,5 +39,3 @@ elif isinstance(df, pd.DataFrame):
             st.success(f"Emails sent to {sent} recipient(s).")
         else:
             st.warning(f"Sent: {sent}; Failed: {failed}.")
-
-    st.dataframe(df, hide_index=True, width="stretch")

--- a/pages/11_Event_Code_Admin.py
+++ b/pages/11_Event_Code_Admin.py
@@ -75,7 +75,7 @@ with col_time:
 
 expires_at = build_expires_at(exp_date, exp_time, tz_name)
 
-if st.button("Generate New Code", type="primary", use_container_width=True):
+if st.button("Generate New Code", type="primary", width="stretch"):
     if not is_expiry_valid(expires_at):
         st.error("Expiration must be in the future.")
     else:

--- a/pages/11_Event_Code_Admin.py
+++ b/pages/11_Event_Code_Admin.py
@@ -12,7 +12,7 @@ from services.event_codes import (
     get_active_code,
     is_expiry_valid,
 )
-from services.events import get_all_events
+from services.events import closest_event_index, get_all_events
 from utils.auth import get_current_user, require_role
 from utils.db_schema_crud import get_user_by_email
 
@@ -57,20 +57,9 @@ with col_event:
         f"{e.get('event_type', '').upper()} | {e.get('start_date', '')} | {e.get('event_name', '')}"
         for e in all_events
     ]
-    today = date.today()
-
-    def _date_distance(event: dict) -> int:
-        try:
-            return abs(
-                (date.fromisoformat(str(event.get("start_date", ""))) - today).days
-            )
-        except (ValueError, TypeError):
-            return 999999
-
-    default_index = min(
-        range(len(all_events)), key=lambda i: _date_distance(all_events[i])
+    selected_label = st.selectbox(
+        "Event", event_labels, index=closest_event_index(all_events)
     )
-    selected_label = st.selectbox("Event", event_labels, index=default_index)
     selected_event = all_events[event_labels.index(selected_label)]
 
 with col_tz:
@@ -105,9 +94,19 @@ if st.button("Generate New Code", type="primary", use_container_width=True):
 
 st.divider()
 
-active_code = get_active_code(selected_event["_id"])
+_selected_event_id = selected_event["_id"]
 
-if active_code:
+
+@st.fragment(run_every=30)
+def _active_code_panel(event_id: str, tz: str) -> None:
+    active_code = get_active_code(event_id)
+
+    if not active_code:
+        st.info(
+            "No active code for the selected event. Use **Generate New Code** above."
+        )
+        return
+
     code_str = str(active_code.get("code", ""))
     code_expires_at = active_code.get("expires_at")
 
@@ -147,13 +146,13 @@ if active_code:
             code_expires_at = code_expires_at.replace(tzinfo=timezone.utc)
         now = datetime.now(timezone.utc)
         remaining_secs = (code_expires_at - now).total_seconds()
-        local_expires = code_expires_at.astimezone(ZoneInfo(tz_name))
+        local_expires = code_expires_at.astimezone(ZoneInfo(tz))
         if remaining_secs > 0:
             mins = int(remaining_secs // 60)
             secs = int(remaining_secs % 60)
             st.caption(
                 f"Expires {local_expires.strftime('%Y-%m-%d %I:%M %p %Z')}"
-                f" ({mins}m {secs}s remaining)"
+                f" — {mins}m {secs}s remaining"
             )
         else:
             st.warning("This code has expired. Generate a new one above.")
@@ -165,5 +164,5 @@ if active_code:
         else:
             st.error("Could not expire code.")
 
-else:
-    st.info("No active code for the selected event. Use **Generate New Code** above.")
+
+_active_code_panel(_selected_event_id, tz_name)

--- a/pages/1_Dashboard.py
+++ b/pages/1_Dashboard.py
@@ -8,9 +8,9 @@ import streamlit as st
 
 from bson import ObjectId
 
+from services.events import closest_event_index
 from utils.auth import get_current_user, require_role
 from utils.db import get_collection, get_db
-from utils.at_risk_email import send_at_risk_emails
 
 _DEFAULT_DAYS = 30
 _MAX_ROWS = 2000
@@ -300,14 +300,17 @@ else:
             # Keep the event_id hidden but available for selection.
             st.dataframe(
                 summary_df.drop(columns=["_event_id"]),
-                width="stretch",
+                use_container_width=True,
                 hide_index=True,
             )
 
+            _summary_events = [
+                event_by_id.get(eid, {}) for eid in summary_df["_event_id"]
+            ]
             selected_label = st.selectbox(
                 "Select an event to view cadets",
                 options=list(summary_df["Event"]),
-                index=0,
+                index=closest_event_index(_summary_events),
             )
 
             selected_row = summary_df.loc[summary_df["Event"] == selected_label].iloc[0]
@@ -350,15 +353,14 @@ else:
                     else:
                         styler = styler.applymap(_status_cell_style, subset=["Status"])
 
-                    st.dataframe(styler, width="stretch", hide_index=True)
+                    leg1, leg2, leg3 = st.columns(3)
+                    with leg1:
+                        st.success("Present")
+                    with leg2:
+                        st.error("Absent")
+                    with leg3:
+                        st.warning("Excused")
 
-                st.subheader("Legend")
-                c1, c2, c3 = st.columns(3)
-                with c1:
-                    st.success("Present")
-                with c2:
-                    st.error("Absent")
-                with c3:
-                    st.warning("Excused")
+                    st.dataframe(styler, use_container_width=True, hide_index=True)
 
             st.divider()

--- a/pages/1_Dashboard.py
+++ b/pages/1_Dashboard.py
@@ -300,7 +300,7 @@ else:
             # Keep the event_id hidden but available for selection.
             st.dataframe(
                 summary_df.drop(columns=["_event_id"]),
-                use_container_width=True,
+                width="stretch",
                 hide_index=True,
             )
 
@@ -361,6 +361,6 @@ else:
                     with leg3:
                         st.warning("Excused")
 
-                    st.dataframe(styler, use_container_width=True, hide_index=True)
+                    st.dataframe(styler, width="stretch", hide_index=True)
 
             st.divider()

--- a/pages/2_Attendance_Submission.py
+++ b/pages/2_Attendance_Submission.py
@@ -3,28 +3,21 @@ from __future__ import annotations
 import streamlit as st
 
 from services.attendance import is_already_checked_in
+from services.cadet_attendance import get_cadet_flight_label, load_cadet_flights
 from services.event_codes import validate_code
 from utils.auth import get_current_user, require_auth
+from utils.auth_logic import user_has_any_role
 from utils.db_schema_crud import (
     create_attendance_record,
     get_attendance_by_cadet,
     get_cadet_by_user_id,
+    get_event_by_id,
     get_user_by_email,
 )
-from services.attendance import (
-    generate_attendance_password,
-    is_already_checked_in,
-    is_within_checkin_window,
-)
-from utils.db_schema_crud import get_cadet_by_user_id, get_user_by_email
-from utils.audit_log import log_checkin_attempt
-from utils.checkin_codes import issue_checkin_code, validate_checkin_code
-from services.attendance import generate_attendance_password
-from utils.auth_logic import user_has_any_role
 
 
 require_auth()
-st.title("Attendance Submission")
+st.title("Attendance")
 
 current_user = get_current_user()
 assert current_user is not None
@@ -35,40 +28,105 @@ if not user:
     st.stop()
 assert user is not None
 
-role = get_current_user()
 cadet = get_cadet_by_user_id(user["_id"])
 if not cadet:
-    if not user_has_any_role(role, ["admin"]):
-        st.error("No cadet profile found for your account.")
-        st.stop()
-else: 
-    assert cadet is not None
+    if user_has_any_role(current_user, ["admin"]):
+        st.info(
+            "Admin accounts do not have a cadet profile. Attendance submission is for cadets only."
+        )
+    else:
+        st.error(
+            "No cadet profile is linked to your account. "
+            "If you are a cadet, contact your cadre to have a profile created."
+        )
+    st.stop()
+assert cadet is not None
 
 cadet_id = cadet["_id"]
 
-code = st.text_input("Enter event code", max_chars=6, placeholder="000000")
+first = str(current_user.get("first_name", "") or "").strip()
+last = str(current_user.get("last_name", "") or "").strip()
+rank = str(cadet.get("rank", "") or "").strip()
+flights = load_cadet_flights(cadet)
+flight_label = get_cadet_flight_label(cadet, flights)
+name_parts = [p for p in [rank, first, last] if p]
+st.caption(f"Checking in as **{' '.join(name_parts)}** · Flight: {flight_label}")
+st.divider()
 
-if st.button("Report In", type="primary"):
-    if not code.strip():
-        st.error("Please enter a code.")
+st.subheader("Enter your 6-digit event code")
+
+code = st.text_input(
+    "Event code",
+    max_chars=6,
+    placeholder="000000",
+    label_visibility="collapsed",
+)
+
+code_clean = code.strip()
+
+event_code = None
+already_checked_in = False
+
+if len(code_clean) == 6:
+    event_code = validate_code(code_clean)
+    if event_code is None:
+        st.error("Invalid or expired code.")
     else:
-        event_code = validate_code(code.strip())
-        if event_code is None:
-            st.error("Invalid or expired code.")
-        else:
-            event_id = event_code["event_id"]
-            existing = get_attendance_by_cadet(cadet_id)
-            if is_already_checked_in(str(event_id), str(cadet_id), existing):
-                st.info("You are already checked in for this event.")
+        event = get_event_by_id(event_code["event_id"])
+        if event:
+            event_name = str(event.get("event_name", "") or "Event")
+            event_type = (event.get("event_type") or "").upper()
+            start = event.get("start_date")
+            if hasattr(start, "strftime"):
+                date_str = start.strftime("%B %d, %Y")
+            elif start:
+                date_str = str(start)[:10]
             else:
-                result = create_attendance_record(
-                    event_id=event_id,
-                    cadet_id=cadet_id,
-                    status="present",
-                    recorded_by_user_id=user["_id"],
+                date_str = ""
+
+            existing = get_attendance_by_cadet(cadet_id)
+            already_checked_in = is_already_checked_in(
+                str(event_code["event_id"]), str(cadet_id), existing
+            )
+
+            if already_checked_in:
+                st.success(
+                    f"You are already checked in for **{event_name}**"
+                    + (f" ({event_type} · {date_str})" if date_str else "")
+                    + "."
                 )
-                if result is None:
-                    st.error("Database unavailable. Could not record attendance.")
-                else:
-                    st.success("Checked in!")
-                    st.balloons()
+            else:
+                label = event_name
+                if event_type:
+                    label += f" · {event_type}"
+                if date_str:
+                    label += f" · {date_str}"
+                st.info(label)
+
+button_disabled = event_code is None or already_checked_in
+
+if (
+    st.button("Report In", type="primary", disabled=button_disabled)
+    and event_code is not None
+):
+    existing = get_attendance_by_cadet(cadet_id)
+    if is_already_checked_in(str(event_code["event_id"]), str(cadet_id), existing):
+        st.info("You are already checked in for this event.")
+    else:
+        result = create_attendance_record(
+            event_id=event_code["event_id"],
+            cadet_id=cadet_id,
+            status="present",
+            recorded_by_user_id=user["_id"],
+        )
+        if result is None:
+            st.error("Database unavailable. Could not record attendance.")
+        else:
+            event = get_event_by_id(event_code["event_id"])
+            event_name = (
+                str(event.get("event_name", "") or "the event")
+                if event
+                else "the event"
+            )
+            st.success(f"Checked in for **{event_name}**!")
+            st.balloons()

--- a/pages/2_Attendance_Submission.py
+++ b/pages/2_Attendance_Submission.py
@@ -17,7 +17,7 @@ from utils.db_schema_crud import (
 
 
 require_auth()
-st.title("Attendance")
+st.title("Attendance Submission")
 
 current_user = get_current_user()
 assert current_user is not None

--- a/pages/3_Cadets.py
+++ b/pages/3_Cadets.py
@@ -68,8 +68,6 @@ def add_cadet():
         if st.session_state.success_time:
             if time.time() - st.session_state.success_time < 3:
                 st.success(st.session_state.success_msg)
-                time.sleep(1)
-                st.rerun()
             else:
                 st.session_state.success_time = None
                 st.session_state.success_msg = None
@@ -152,8 +150,6 @@ def show_cadets():
     if st.session_state.success_time:
         if time.time() - st.session_state.success_time < 3:
             st.success(st.session_state.success_msg)
-            time.sleep(1)
-            st.rerun()
         else:
             st.session_state.success_time = None
             st.session_state.success_msg = None
@@ -179,7 +175,7 @@ def show_cadets():
         rows,
         columns=pd.Index(["No.", "First Name", "Last Name", "Email", "Rank"]),
     )
-    st.dataframe(df, hide_index=True, width="stretch")
+    st.dataframe(df, hide_index=True, use_container_width=True)
 
     st.divider()
 
@@ -282,7 +278,7 @@ with tab_import:
                 }
                 for c in result["created"]
             ]
-            st.dataframe(rows, width="stretch")
+            st.dataframe(rows, hide_index=True, use_container_width=True)
         if result["skipped"]:
             st.info(f"Skipped {len(result['skipped'])} already-existing account(s).")
         if result["errors"]:

--- a/pages/3_Cadets.py
+++ b/pages/3_Cadets.py
@@ -175,7 +175,7 @@ def show_cadets():
         rows,
         columns=pd.Index(["No.", "First Name", "Last Name", "Email", "Rank"]),
     )
-    st.dataframe(df, hide_index=True, use_container_width=True)
+    st.dataframe(df, hide_index=True, width="stretch")
 
     st.divider()
 
@@ -278,7 +278,7 @@ with tab_import:
                 }
                 for c in result["created"]
             ]
-            st.dataframe(rows, hide_index=True, use_container_width=True)
+            st.dataframe(rows, hide_index=True, width="stretch")
         if result["skipped"]:
             st.info(f"Skipped {len(result['skipped'])} already-existing account(s).")
         if result["errors"]:

--- a/pages/4_Flight_Management.py
+++ b/pages/4_Flight_Management.py
@@ -16,103 +16,115 @@ require_role("admin", "cadre")
 
 st.title("Flight Management")
 
+if "confirm_delete_flight_id" not in st.session_state:
+    st.session_state.confirm_delete_flight_id = None
+
 # ----------------------------
 # Create Flight Section
 # ----------------------------
 
-st.subheader("Create New Flight")
-
-flight_name = st.text_input("Flight Name")
-
 cadet_display_map = build_cadet_display_map()
 
-selected_display = st.selectbox(
-    "Select Commander (Cadet)",
-    options=list(cadet_display_map.keys()) if cadet_display_map else [],
-)
+with st.expander("Create New Flight", expanded=False):
+    with st.form("create_flight_form"):
+        flight_name = st.text_input("Flight Name")
+        selected_display = st.selectbox(
+            "Select Commander (Cadet)",
+            options=list(cadet_display_map.keys()) if cadet_display_map else [],
+        )
+        submitted = st.form_submit_button("Create Flight", type="primary")
 
-selected_commander = cadet_display_map.get(selected_display)
+    if submitted:
+        selected_commander = cadet_display_map.get(selected_display)
+        if flight_name and selected_commander:
+            create_flight(flight_name, selected_commander)
+            st.success("Flight created successfully!")
+            st.rerun()
+        else:
+            st.warning("Please fill all fields.")
 
-if st.button("Create Flight"):
-    if flight_name and selected_commander:
-        create_flight(flight_name, selected_commander)
-        st.success("Flight created successfully!")
-        st.rerun()
-    else:
-        st.warning("Please fill all fields.")
-
+st.divider()
 
 # ----------------------------
 # Existing Flights
 # ----------------------------
 
-st.subheader("Existing Flights")
-
 flights = get_all_flights()
 
 if not flights:
     st.info("No flights created yet.")
+else:
+    st.subheader(f"Flights ({len(flights)})")
+    for flight in flights:
+        flight_id = str(flight["_id"])
 
-for flight in flights:
-    st.markdown("---")
-    st.write(f"### {flight['name']}")
-
-    commander = get_cadet_by_id(flight["commander_cadet_id"])
-    if commander:
-        user = get_user_by_id(commander["user_id"])
-        if user:
-            name = f"{user.get('first_name', '')} {user.get('last_name', '')}".strip()
-            rank = commander.get("rank", "")
-            st.write(f"Commander: {name} ({rank})")
-
-    st.write("Assign / Reassign Cadet")
-
-    cadet_display_map = build_cadet_display_map()
-
-    cadet_to_assign_display = st.selectbox(
-        f"Select Cadet for {flight['name']}",
-        options=list(cadet_display_map.keys()),
-        key=f"assign_{flight['_id']}",
-    )
-
-    cadet_to_assign = cadet_display_map.get(cadet_to_assign_display)
-
-    if st.button("Assign Cadet", key=f"btn_{flight['_id']}"):
-        if cadet_to_assign:
-            assign_cadet_to_flight(cadet_to_assign, flight["_id"])
-            st.success("Cadet assigned successfully!")
-            st.rerun()
-
-    # Show Cadets in Flight
-    st.write("Cadets in this Flight:")
-
-    cadets_in_flight = get_cadets_by_flight(flight["_id"])
-
-    if cadets_in_flight:
-        for cadet in cadets_in_flight:
-            user = get_user_by_id(cadet["user_id"])
-
+        commander_name = "—"
+        commander_rank = ""
+        commander = get_cadet_by_id(flight["commander_cadet_id"])
+        if commander:
+            user = get_user_by_id(commander["user_id"])
             if user:
-                name = (
+                commander_name = (
                     f"{user.get('first_name', '')} {user.get('last_name', '')}".strip()
                 )
-                rank = cadet.get("rank", "")
+                commander_rank = commander.get("rank", "")
 
-                col1, col2 = st.columns([4, 1])
+        cadets_in_flight = get_cadets_by_flight(flight["_id"])
+        cadet_count = len(cadets_in_flight)
 
-                with col1:
-                    st.write(f"{name} ({rank})")
+        with st.expander(
+            f"{flight['name']}  ·  Commander: {commander_name}  ·  {cadet_count} cadet(s)"
+        ):
+            st.caption(
+                f"Commander: {commander_name}"
+                + (f" ({commander_rank})" if commander_rank else "")
+            )
 
-                with col2:
-                    if st.button("Unassign", key=f"unassign_{cadet['_id']}"):
-                        unassign_cadet_from_flight(cadet["_id"])
-                        st.success("Cadet unassigned from flight.")
-                        st.rerun()
-    else:
-        st.write("No cadets assigned yet.")
+            st.markdown("**Assign / Reassign Cadet**")
+            cadet_to_assign_display = st.selectbox(
+                "Select cadet",
+                options=list(cadet_display_map.keys()),
+                key=f"assign_{flight_id}",
+                label_visibility="collapsed",
+            )
+            cadet_to_assign = cadet_display_map.get(cadet_to_assign_display)
+            if st.button("Assign to Flight", key=f"btn_{flight_id}"):
+                if cadet_to_assign:
+                    assign_cadet_to_flight(cadet_to_assign, flight["_id"])
+                    st.success("Cadet assigned.")
+                    st.rerun()
 
-    # Delete Flight
-    if st.button("Delete Flight", key=f"delete_{flight['_id']}"):
-        delete_flight(flight["_id"])
-        st.success("Flight deleted.")
-        st.rerun()
+            st.markdown("**Cadets in this Flight**")
+            if cadets_in_flight:
+                for cadet in cadets_in_flight:
+                    user = get_user_by_id(cadet["user_id"])
+                    if user:
+                        name = f"{user.get('first_name', '')} {user.get('last_name', '')}".strip()
+                        rank = cadet.get("rank", "")
+                        col1, col2 = st.columns([5, 1])
+                        with col1:
+                            st.write(f"{name} ({rank})")
+                        with col2:
+                            if st.button("Unassign", key=f"unassign_{cadet['_id']}"):
+                                unassign_cadet_from_flight(cadet["_id"])
+                                st.rerun()
+            else:
+                st.caption("No cadets assigned yet.")
+
+            st.divider()
+            if st.session_state.confirm_delete_flight_id == flight_id:
+                st.warning(f"Delete **{flight['name']}**? This cannot be undone.")
+                c1, c2 = st.columns(2)
+                if c1.button(
+                    "Yes, delete", key=f"confirm_del_{flight_id}", type="primary"
+                ):
+                    delete_flight(flight["_id"])
+                    st.session_state.confirm_delete_flight_id = None
+                    st.rerun()
+                if c2.button("Cancel", key=f"cancel_del_{flight_id}"):
+                    st.session_state.confirm_delete_flight_id = None
+                    st.rerun()
+            else:
+                if st.button("Delete Flight", key=f"delete_{flight_id}"):
+                    st.session_state.confirm_delete_flight_id = flight_id
+                    st.rerun()

--- a/pages/5_Waivers.py
+++ b/pages/5_Waivers.py
@@ -184,7 +184,7 @@ def show_waivers(
         )
 
     df = pd.DataFrame(rows, columns=pd.Index(["Event", "Date", "Status"]))
-    st.dataframe(df, hide_index=True, use_container_width=True)
+    st.dataframe(df, hide_index=True, width="stretch")
 
     st.divider()
 

--- a/pages/5_Waivers.py
+++ b/pages/5_Waivers.py
@@ -1,13 +1,13 @@
 import streamlit as st
 import pandas as pd
 
-from bson import ObjectId
 
 from services.waivers import (
     get_absent_records_without_waiver,
     get_all_waivers_for_cadet,
     resubmit_auto_denied_waiver,
     withdraw_waiver,
+    WAIVER_STATUS_BADGE,
 )
 from utils.auth import get_current_user, require_role
 from utils.db_schema_crud import (
@@ -24,12 +24,7 @@ from datetime import date, datetime, timedelta
 from utils.auth_logic import user_has_any_role
 from scripts.demo_admin import get_temp_cadet
 
-STATUS_BADGE = {
-    "pending": "🟡 Pending",
-    "approved": "🟢 Approved",
-    "denied": "🔴 Denied",
-    "withdrawn": "⚪ Withdrawn",
-}
+STATUS_BADGE = WAIVER_STATUS_BADGE
 
 
 def load_waiver_data(cadet_id) -> tuple[list[dict], dict, dict]:
@@ -189,7 +184,7 @@ def show_waivers(
         )
 
     df = pd.DataFrame(rows, columns=pd.Index(["Event", "Date", "Status"]))
-    st.dataframe(df, hide_index=True, width="stretch")
+    st.dataframe(df, hide_index=True, use_container_width=True)
 
     st.divider()
 
@@ -354,7 +349,7 @@ def waiver_form(
 
 
 require_role("cadet")
-st.title("Submit Waiver Request")
+st.title("My Waivers")
 
 if "waiver_record_id" not in st.session_state:
     st.session_state.waiver_record_id = None
@@ -388,24 +383,19 @@ if not user:
     st.stop()
 assert user is not None
 
-# cadet = get_cadet_by_user_id(user["_id"])
-# if not cadet:
-#     st.error("You must be a cadet to submit a waiver request.")
-#     st.stop()
-# assert cadet is not None
-
-role = get_current_user()
 cadet = get_cadet_by_user_id(user["_id"])
 if not cadet:
-    if not user_has_any_role(role, ["admin"]):
+    if not user_has_any_role(current_user, ["admin"]):
         st.error("No cadet profile found for your account.")
         st.stop()
-    else:
-        cadet = get_temp_cadet()
-else: 
-    assert cadet is not None
+    cadet = get_temp_cadet()
 
 records, waivers_by_record_id, events_by_id = load_waiver_data(cadet["_id"])
 
-waiver_form(str(user["_id"]), records, waivers_by_record_id, events_by_id)
 show_waivers(records, waivers_by_record_id, events_by_id)
+
+st.divider()
+with st.expander(
+    "Submit New Waiver Request", expanded=st.session_state.waiver_record_id is not None
+):
+    waiver_form(str(user["_id"]), records, waivers_by_record_id, events_by_id)

--- a/pages/6_Event_Management_CRUD.py
+++ b/pages/6_Event_Management_CRUD.py
@@ -136,7 +136,7 @@ else:
         ]
     )
 
-    st.dataframe(df, use_container_width=True, hide_index=True)
+    st.dataframe(df, width="stretch", hide_index=True)
 
     # Delete section below the table
     st.markdown("**Delete an Event**")

--- a/pages/6_Event_Management_CRUD.py
+++ b/pages/6_Event_Management_CRUD.py
@@ -6,6 +6,9 @@ from utils.auth import require_role, get_current_user
 
 require_role("admin", "cadre")
 
+if "confirm_delete_event_id" not in st.session_state:
+    st.session_state.confirm_delete_event_id = None
+
 st.title("Event Management")
 
 # ── helpers ──────────────────────────────────────────────────────────────────
@@ -133,7 +136,7 @@ else:
         ]
     )
 
-    st.dataframe(df, width="stretch", hide_index=True)
+    st.dataframe(df, use_container_width=True, hide_index=True)
 
     # Delete section below the table
     st.markdown("**Delete an Event**")
@@ -143,9 +146,22 @@ else:
     selected_label = st.selectbox("Select event to delete", event_labels)
     selected_event = events[event_labels.index(selected_label)]
 
-    if st.button("Delete Selected Event", type="primary"):
-        if delete_event(selected_event["_id"]):
-            st.success("Event deleted.")
+    if st.session_state.confirm_delete_event_id == selected_event["_id"]:
+        st.warning(
+            f"Delete **{selected_event.get('event_name', 'this event')}**? This cannot be undone."
+        )
+        c1, c2 = st.columns(2)
+        if c1.button("Yes, delete", type="primary"):
+            if delete_event(selected_event["_id"]):
+                st.session_state.confirm_delete_event_id = None
+                st.success("Event deleted.")
+                st.rerun()
+            else:
+                st.error("Could not delete event.")
+        if c2.button("Cancel"):
+            st.session_state.confirm_delete_event_id = None
             st.rerun()
-        else:
-            st.error("Could not delete event.")
+    else:
+        if st.button("Delete Selected Event"):
+            st.session_state.confirm_delete_event_id = selected_event["_id"]
+            st.rerun()

--- a/pages/6_Waiver_Review.py
+++ b/pages/6_Waiver_Review.py
@@ -9,17 +9,14 @@ from services.waiver_review import (
     get_waivers,
     submit_decision,
 )
+from services.waivers import WAIVER_STATUS_BADGE
 
 from utils.auth import get_current_user, require_role
 from utils.db_schema_crud import get_user_by_email
 from utils.export import to_excel
 
 
-STATUS_BADGE = {
-    "pending": "🟡 Pending",
-    "approved": "🟢 Approved",
-    "denied": "🔴 Denied",
-}
+STATUS_BADGE = WAIVER_STATUS_BADGE
 
 
 require_role("admin", "cadre", "flight_commander")
@@ -42,7 +39,7 @@ assert approver_user is not None
 approver_id = approver_user["_id"]
 
 status_filter = st.selectbox(
-    "Status", ["pending", "approved", "denied", "all"], index=0
+    "Status", ["all", "pending", "approved", "denied"], index=0
 )
 flight_filter = st.selectbox("Flight", get_flight_options(), index=0)
 cadet_search = st.text_input("Cadet search (name or email)", "").strip().lower()
@@ -98,22 +95,6 @@ if isinstance(export_df, str):
     st.info(export_df)
     st.stop()
 
-st.divider()
-col1, col2, spacer = st.columns([2, 2, 10])
-if isinstance(export_df, pd.DataFrame):
-    col1.download_button(
-        "Export CSV",
-        export_df.to_csv(index=False).encode("utf-8"),
-        "waivers.csv",
-        "text/csv",
-    )
-    col2.download_button(
-        "Export Excel",
-        to_excel(export_df),
-        "waivers.xlsx",
-        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-    )
-
 if not rows:
     st.info("No waivers matched the selected filters.")
     st.stop()
@@ -163,3 +144,19 @@ for w in rows:
                         st.rerun()
                     else:
                         st.error(err)
+
+st.divider()
+col1, col2, spacer = st.columns([2, 2, 10])
+if isinstance(export_df, pd.DataFrame):
+    col1.download_button(
+        "Export CSV",
+        export_df.to_csv(index=False).encode("utf-8"),
+        "waivers.csv",
+        "text/csv",
+    )
+    col2.download_button(
+        "Export Excel",
+        to_excel(export_df),
+        "waivers.xlsx",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    )

--- a/pages/7_Flight_Commander_Live_View.py
+++ b/pages/7_Flight_Commander_Live_View.py
@@ -14,6 +14,7 @@ from utils.db_schema_crud import (
     get_user_by_email,
     get_user_by_id,
 )
+from services.events import closest_event_index
 from utils.flight_commander_view import (
     _ensure_utc,
     build_checkin_view,
@@ -114,7 +115,7 @@ def live_checkin_fragment() -> None:
             )
         return name
 
-    default_index = 0
+    default_index = closest_event_index(active_events)
     if previous_event_id is not None:
         for idx, ev in enumerate(active_events):
             if ev.get("_id") == previous_event_id:
@@ -185,7 +186,6 @@ def live_checkin_fragment() -> None:
             st.write("Everyone is checked in.")
 
     st.divider()
-    st.caption("Missing cadets are highlighted in red.")
 
 
 live_checkin_fragment()

--- a/pages/8_Cadet_Attendance.py
+++ b/pages/8_Cadet_Attendance.py
@@ -147,7 +147,7 @@ def show_attendance_table(rows: list[dict]):
         table_rows,
         columns=pd.Index(["Event", "Date", "Type", "Status", "Waiver"]),
     )
-    st.dataframe(df, hide_index=True, use_container_width=True)
+    st.dataframe(df, hide_index=True, width="stretch")
 
     st.divider()
 

--- a/pages/8_Cadet_Attendance.py
+++ b/pages/8_Cadet_Attendance.py
@@ -13,11 +13,10 @@ from services.cadet_attendance import (
     filter_rows,
     get_cadet_flight_label,
 )
+from services.waivers import WAIVER_STATUS_BADGE
+from utils.at_risk_email import PT_ABSENCE_THRESHOLD, LLAB_ABSENCE_THRESHOLD
 from utils.auth_logic import user_has_any_role
 from scripts.demo_admin import get_temp_cadet
-
-PT_ABSENCE_THRESHOLD = 9
-LLAB_ABSENCE_THRESHOLD = 2
 
 STATUS_BADGE = {
     "present": "🟢 Present",
@@ -26,12 +25,7 @@ STATUS_BADGE = {
     "waived": "🟡 Excused",
 }
 
-WAIVER_BADGE = {
-    "pending": "🟡 Pending",
-    "approved": "🟢 Approved",
-    "denied": "🔴 Denied",
-    "withdrawn": "⚪ Withdrawn",
-}
+WAIVER_BADGE = WAIVER_STATUS_BADGE
 
 
 def show_risk_banner(pt_absences: int, llab_absences: int):
@@ -153,7 +147,7 @@ def show_attendance_table(rows: list[dict]):
         table_rows,
         columns=pd.Index(["Event", "Date", "Type", "Status", "Waiver"]),
     )
-    st.dataframe(df, hide_index=True, width="stretch")
+    st.dataframe(df, hide_index=True, use_container_width=True)
 
     st.divider()
 
@@ -217,16 +211,12 @@ if not user:
     st.stop()
 assert user is not None
 
-role = get_current_user()
 cadet = get_cadet_by_user_id(user["_id"])
 if not cadet:
-    if not user_has_any_role(role, ["admin"]):
+    if not user_has_any_role(current_user, ["admin"]):
         st.error("No cadet profile found for your account.")
         st.stop()
-    else:
-        cadet = get_temp_cadet()
-else: 
-    assert cadet is not None
+    cadet = get_temp_cadet()
 
 records, events, waivers = load_attendance_db(cadet["_id"])
 rows = cadet_attendance(records, events, waivers)

--- a/pages/8_User_Management.py
+++ b/pages/8_User_Management.py
@@ -151,18 +151,18 @@ st.caption("Create, edit, and delete user accounts and roles.")
 # Create New User
 # ----------------------------
 
-st.subheader("Create New User")
-with st.form("create_user_form", clear_on_submit=True):
-    col1, col2 = st.columns(2)
-    with col1:
-        first_name = st.text_input("First Name")
-        email = st.text_input("Email")
-    with col2:
-        last_name = st.text_input("Last Name")
-        role = st.selectbox("Role", sorted(ALLOWED_ROLES))
+with st.expander("Create New User", expanded=False):
+    with st.form("create_user_form", clear_on_submit=True):
+        col1, col2 = st.columns(2)
+        with col1:
+            first_name = st.text_input("First Name")
+            email = st.text_input("Email")
+        with col2:
+            last_name = st.text_input("Last Name")
+            role = st.selectbox("Role", sorted(ALLOWED_ROLES))
 
-    password = st.text_input("Temporary Password", type="password")
-    create_submitted = st.form_submit_button("Create User")
+        password = st.text_input("Temporary Password", type="password")
+        create_submitted = st.form_submit_button("Create User", type="primary")
 
     if create_submitted:
         # Load current users for email-uniqueness validation.
@@ -180,7 +180,6 @@ with st.form("create_user_form", clear_on_submit=True):
             for field, msg in errors.items():
                 st.error(f"{field.capitalize()}: {msg}")
         else:
-            # create_user expects first_name, last_name, email, password, roles
             result = create_user(
                 first_name=payload["first_name"],
                 last_name=payload["last_name"],
@@ -254,7 +253,7 @@ else:
             ],
             columns=pd.Index(["Name", "Email", "Role"]),
         )
-        st.dataframe(df, hide_index=True, width="stretch")
+        st.dataframe(df, hide_index=True, use_container_width=True)
 
         filtered_ids = [s["id"] for s in filtered]
         if st.session_state.admin_users_selected not in filtered_ids:

--- a/pages/8_User_Management.py
+++ b/pages/8_User_Management.py
@@ -253,7 +253,7 @@ else:
             ],
             columns=pd.Index(["Name", "Email", "Role"]),
         )
-        st.dataframe(df, hide_index=True, use_container_width=True)
+        st.dataframe(df, hide_index=True, width="stretch")
 
         filtered_ids = [s["id"] for s in filtered]
         if st.session_state.admin_users_selected not in filtered_ids:

--- a/pages/9_Account_Settings.py
+++ b/pages/9_Account_Settings.py
@@ -6,8 +6,6 @@ from utils.auth import require_auth, get_current_user
 from utils.db_schema_crud import get_user_by_email, update_user
 from utils.password import verify_password
 
-st.set_page_config(page_title="Account Settings: RollCall", page_icon="🪖")
-
 require_auth()
 
 st.title("Account Settings")

--- a/scripts/demo_admin.py
+++ b/scripts/demo_admin.py
@@ -1,40 +1,12 @@
-from datetime import datetime, timezone
 from bson import ObjectId
 
-def get_temp_cadet():
 
+def get_temp_cadet() -> dict:
     return {
-        #=== ID ===#
         "_id": str(ObjectId()),
-        
-        #=== Users ===#
-        "username": "Demo Admin",
-        "first_name": "Demo",
-        "last_name": "Admin",
-        "name": "Demo Admin",
-        "email": "demoAdmin@rollcall.local",
-        "password": "password",
-        "password_hash": "password",
-        "role": "cadet",
-        "roles": ["cadet"],
-        "created_at": datetime.now(timezone.utc),
-
-        #=== Cadets ===#
         "user_id": str(ObjectId()),
-        "rank": 100,
         "first_name": "Demo",
         "last_name": "Admin",
-        "email": "demoAdmin@rollcall.local",
-
-        #=== Events ===#
-
-        #=== Event Assignments ===#
-
-        #=== Attendance Records ===#
-
-        #=== Waivers ===#
-
-        #=== Waiver Approvals ===#
-
-        #=== Flights ===#
+        "email": "admin@rollcall.local",
+        "rank": "",
     }

--- a/services/at_risk_cadets.py
+++ b/services/at_risk_cadets.py
@@ -15,10 +15,7 @@ def get_df() -> pd.DataFrame | str:
         return "No cadets found."
 
     rows: list[dict[str, str | int]] = []
-    cadet_by_id: dict[str, dict] = {}
     for i, cadet in enumerate(cadets):
-        cid = str(cadet.get("_id"))
-        cadet_by_id[cid] = cadet
         rows.append(
             {
                 "No.": i + 1,

--- a/services/events.py
+++ b/services/events.py
@@ -1,6 +1,23 @@
-from datetime import date
+from datetime import date, datetime, timezone
 from bson import ObjectId
 from utils.db import get_db
+
+
+def closest_event_index(events: list[dict]) -> int:
+    if not events:
+        return 0
+    today = date.today()
+
+    def _distance(event: dict) -> int:
+        start = event.get("start_date")
+        try:
+            if isinstance(start, datetime):
+                return abs((start.date() - today).days)
+            return abs((date.fromisoformat(str(start)[:10]) - today).days)
+        except (ValueError, TypeError):
+            return 999_999
+
+    return min(range(len(events)), key=lambda i: _distance(events[i]))
 
 
 def get_all_events() -> list[dict]:
@@ -25,12 +42,18 @@ def create_event(
     db = get_db()
     if db is None:
         return False
+    start_dt = datetime(
+        start_date.year, start_date.month, start_date.day, tzinfo=timezone.utc
+    )
+    end_dt = datetime(
+        end_date.year, end_date.month, end_date.day, 23, 59, 59, tzinfo=timezone.utc
+    )
     db.events.insert_one(
         {
             "event_name": name,
             "event_type": event_type,
-            "start_date": start_date.isoformat(),
-            "end_date": end_date.isoformat(),
+            "start_date": start_dt,
+            "end_date": end_dt,
             "created_by_user_id": created_by_user_id,
         }
     )

--- a/services/waivers.py
+++ b/services/waivers.py
@@ -6,6 +6,13 @@ from utils.db_schema_crud import (
     validate_waiver,
 )
 
+WAIVER_STATUS_BADGE: dict[str, str] = {
+    "pending": "🟡 Pending",
+    "approved": "🟢 Approved",
+    "denied": "🔴 Denied",
+    "withdrawn": "⚪ Withdrawn",
+}
+
 
 def get_all_waivers_for_cadet(
     records: list[dict],

--- a/tests/test_attendance_submission.py
+++ b/tests/test_attendance_submission.py
@@ -3,14 +3,19 @@ import pytest
 import subprocess
 import requests
 import requests.adapters
+from pathlib import Path
 from time import sleep, time
 from datetime import datetime, timedelta, timezone
 from selenium import webdriver
 from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.common.exceptions import TimeoutException
 
-URL = "http://localhost:8501"
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_STREAMLIT = str(_REPO_ROOT / ".venv" / "Scripts" / "streamlit.exe")
+
+URL = "http://localhost:15084"
 
 
 # browser options
@@ -97,7 +102,7 @@ def _go_to_attendance(browser):
         "nav.1",
         browser,
         10,
-        lambda d: d.find_element(By.CSS_SELECTOR, "a[href='http://localhost:8501/']"),
+        lambda d: d.find_element(By.CSS_SELECTOR, "a[href='http://localhost:15084/']"),
         "couldn't find the attendance tab label",
     )
     attendance.click()
@@ -105,7 +110,7 @@ def _go_to_attendance(browser):
         "nav.2",
         browser,
         10,
-        lambda d: "Attendance Submission" in d.find_element(By.TAG_NAME, "body").text,
+        lambda d: "6-digit event code" in d.find_element(By.TAG_NAME, "body").text,
         "couldn't verify being on the attendance page",
     )
 
@@ -118,11 +123,12 @@ pytestmark = pytest.mark.e2e
 @pytest.fixture(scope="session", autouse=True)
 def streamlit_server():
     process = subprocess.Popen(
-        ["streamlit", "run", "Home.py", "--server.headless", "true"],
+        [_STREAMLIT, "run", "Home.py", "--server.headless", "true"],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
+        cwd=str(_REPO_ROOT),
     )
-    sleep(3)
+    sleep(5)
     if not _wait_for_server():
         process.terminate()
         pytest.skip("Streamlit server did not start within 15 seconds")
@@ -187,7 +193,7 @@ def test_check_for_username_and_box(browser):
     _wait(
         "Test 2.1",
         browser,
-        10,
+        15,
         lambda d: "Username" in d.find_element(By.TAG_NAME, "body").text,
         "couldn't find the username text",
     )
@@ -246,16 +252,14 @@ def test_check_for_event_code_input(browser):
         "Test 7.1",
         browser,
         10,
-        lambda d: "Enter event code" in d.find_element(By.TAG_NAME, "body").text,
+        lambda d: "6-digit event code" in d.find_element(By.TAG_NAME, "body").text,
         "couldn't find event code label",
     )
     _wait(
         "Test 7.2",
         browser,
         10,
-        lambda d: d.find_element(
-            By.CSS_SELECTOR, "input[aria-label='Enter event code']"
-        ),
+        lambda d: d.find_element(By.CSS_SELECTOR, "input[aria-label='Event code']"),
         "couldn't find event code text input",
     )
 
@@ -275,9 +279,9 @@ def test_check_for_report_in_button(browser):
 
 
 # Test 9
-def test_empty_code_shows_error(browser):
+def test_empty_code_disables_button(browser):
     _go_to_attendance(browser)
-    button = _wait(
+    _wait(
         "Test 9.1",
         browser,
         10,
@@ -286,14 +290,17 @@ def test_empty_code_shows_error(browser):
         ),
         "couldn't find the Report In button",
     )
-    sleep(1)
-    button.click()
     _wait(
         "Test 9.2",
         browser,
         10,
-        lambda d: "Please enter a code" in d.find_element(By.TAG_NAME, "body").text,
-        "couldn't find empty-code error message",
+        lambda d: (
+            d.find_element(
+                By.XPATH, "//button[.//*[contains(text(), 'Report In')]]"
+            ).get_attribute("disabled")
+            is not None
+        ),
+        "Report In button should be disabled when no code is entered",
     )
 
 
@@ -304,23 +311,13 @@ def test_invalid_code_shows_error(browser):
         "Test 10.1",
         browser,
         10,
-        lambda d: d.find_element(
-            By.CSS_SELECTOR, "input[aria-label='Enter event code']"
-        ),
+        lambda d: d.find_element(By.CSS_SELECTOR, "input[aria-label='Event code']"),
         "couldn't find event code input",
     )
     code_input.send_keys("000000")
+    code_input.send_keys(Keys.TAB)
     _wait(
         "Test 10.2",
-        browser,
-        10,
-        lambda d: d.find_element(
-            By.XPATH, "//button[.//*[contains(text(), 'Report In')]]"
-        ),
-        "couldn't find the Report In button",
-    ).click()
-    _wait(
-        "Test 10.3",
         browser,
         10,
         lambda d: "Invalid or expired code" in d.find_element(By.TAG_NAME, "body").text,
@@ -362,7 +359,7 @@ def test_checked_in_success_with_valid_code(browser):
             browser,
             10,
             lambda d: d.find_element(
-                By.CSS_SELECTOR, "a[href='http://localhost:8501/']"
+                By.CSS_SELECTOR, "a[href='http://localhost:15084/']"
             ),
             "couldn't find Attendance nav link",
         ).click()
@@ -370,29 +367,33 @@ def test_checked_in_success_with_valid_code(browser):
             "Test 11.2",
             browser,
             10,
-            lambda d: (
-                "Attendance Submission" in d.find_element(By.TAG_NAME, "body").text
-            ),
-            "couldn't load Attendance Submission page",
+            lambda d: "6-digit event code" in d.find_element(By.TAG_NAME, "body").text,
+            "couldn't load Attendance page",
         )
         code_input = _wait(
             "Test 11.3",
             browser,
             10,
-            lambda d: d.find_element(
-                By.CSS_SELECTOR, "input[aria-label='Enter event code']"
-            ),
+            lambda d: d.find_element(By.CSS_SELECTOR, "input[aria-label='Event code']"),
             "couldn't find event code input",
         )
         code_input.send_keys("999888")
+        code_input.send_keys(Keys.TAB)
         _wait(
             "Test 11.4",
             browser,
             10,
-            lambda d: d.find_element(
-                By.XPATH, "//button[.//*[contains(text(), 'Report In')]]"
+            lambda d: (
+                d.find_element(
+                    By.XPATH, "//button[.//*[contains(text(), 'Report In')]]"
+                ).get_attribute("disabled")
+                is None
             ),
-            "couldn't find Report In button",
+            "Report In button never became enabled after entering valid code",
+        )
+        d = browser
+        d.find_element(
+            By.XPATH, "//button[.//*[contains(text(), 'Report In')]]"
         ).click()
         _wait(
             "Test 11.5",

--- a/utils/auth.py
+++ b/utils/auth.py
@@ -53,6 +53,8 @@ def _get_or_create_authenticator() -> stauth.Authenticate:
 
 
 def restore_session() -> None:
+    if st.session_state.get("_logged_out"):
+        return
     if st.session_state.get("authentication_status"):
         return
 
@@ -88,6 +90,7 @@ def restore_session() -> None:
     st.session_state["email"] = raw_user.get("email")
     st.session_state["roles"] = raw_user.get("roles")
     st.session_state.setdefault("logout", None)
+    st.session_state.pop("_logged_out", None)
 
 
 def ensure_authenticator() -> stauth.Authenticate:
@@ -101,6 +104,8 @@ def init_auth():
     authenticator.login(location="main")
     if st.session_state.get("authentication_status") is False:
         st.error("Incorrect username or password.")
+    elif st.session_state.get("authentication_status"):
+        st.session_state.pop("_logged_out", None)
     return authenticator
 
 

--- a/utils/auth.py
+++ b/utils/auth.py
@@ -55,6 +55,8 @@ def _get_or_create_authenticator() -> stauth.Authenticate:
 def restore_session() -> None:
     if st.session_state.get("_logged_out"):
         return
+    if st.session_state.get("logout"):
+        return
     if st.session_state.get("authentication_status"):
         return
 
@@ -102,10 +104,12 @@ def init_auth():
     authenticator = _get_or_create_authenticator()
 
     authenticator.login(location="main")
+
     if st.session_state.get("authentication_status") is False:
         st.error("Incorrect username or password.")
     elif st.session_state.get("authentication_status"):
         st.session_state.pop("_logged_out", None)
+        st.session_state["logout"] = False
     return authenticator
 
 

--- a/utils/auth_logic.py
+++ b/utils/auth_logic.py
@@ -38,7 +38,7 @@ def extract_user_from_raw(email: str | None, raw: dict) -> dict | None:
     }
 
 
-def user_has_any_role(user: dict | None, roles: tuple[str, ...]) -> bool:
+def user_has_any_role(user: dict | None, roles: list[str] | tuple[str, ...]) -> bool:
     """Return True if user holds at least one of the required roles."""
     if user is None:
         return False


### PR DESCRIPTION
Logout race condition

Clicking logout did nothing for cadets. `restore_session()` reads the JWT from the incoming request cookie, which is still present on the same rerun that logout fires. Fixed by replacing `authenticator.logout()` with a custom sidebar button that clears all auth-related session state, sets a `_logged_out` flag, and reruns. `restore_session()` now checks that flag first and bails out before touching the cookie.

Closest event default

All four event selection dropdowns defaulted to index 0 (newest event, since the list is sorted descending). Added `closest_event_index()` to `services/events.py` and wired it into `10_Commander_Attendance.py`, `11_Event_Code_Admin.py`, `1_Dashboard.py`, and `7_Flight_Commander_Live_View.py`. The existing session-state memory in the live view still takes priority; closest-to-today is only the fallback.

UI layout fixes

- Dashboard: moved the Present/Absent/Excused legend above the cadet status table
- Waiver Review: moved export buttons below the waiver cards; fixed the local `STATUS_BADGE` dict that was missing `"withdrawn"`; default filter changed from "pending" to "all"
- Waivers page: show waiver history first, submit form in a collapsible expander; renamed title to "My Waivers"
- At-Risk Cadets: table renders before the email/export buttons so admins see who will be emailed before acting
- Live Check-In View: removed a caption that described non-existent red highlighting

RBAC and nav cleanup

- Nav labels now match the `st.title()` on each page ("My Waivers", "My Attendance", "Live Check-In View")
- Admin role simulator dropdown shows "Flight Commander" instead of the raw `flight_commander` key
- `WAIVER_STATUS_BADGE` consolidated into `services/waivers.py` as a single source of truth; removed three per-page copies, one of which was missing the `withdrawn` state
- `user_has_any_role` type annotation corrected to accept `tuple[str, ...]` alongside `list[str]`
- Attendance page error message now distinguishes between an admin visiting a cadet-only page and a cadet with no linked profile

E2E tests

Corrected port (8501 -> 15084), hardcoded Streamlit executable path from `.venv`, fixed event code input selector and button XPath, added `Keys.TAB` after typing to trigger Streamlit's blur rerun, added a wait-for-enabled check before clicking Report In.

Closes #185
Closes #142
Closes #186
Closes #188
Closes #189