### PR TITLE
Remove manual sys.path setup in test_flight_management.py (#152)

### DIFF
--- a/tests/test_flight_management.py
+++ b/tests/test_flight_management.py
@@ -1,10 +1,6 @@
-import sys
-import os
 from unittest.mock import patch, MagicMock
 from bson import ObjectId
 import pytest
-
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from utils.db_schema_crud import unassign_cadet_from_flight
 


### PR DESCRIPTION
Closes #152

Remove lines of code regarding sys.path:

Remove lines:

import sys
import os

sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))