### PR TITLE
Standardize cancel buttons to type=secondary (#146)

### DIFF
--- a/pages/3_Cadets.py
+++ b/pages/3_Cadets.py
@@ -103,11 +103,13 @@ def edit_cadet(cadet):
                 },
             )
             st.session_state.editing_id = None
+            st.session_state.success_msg = "Cadet updated successfully!"
+            st.session_state.success_time = time.time()
             st.rerun()
         else:
             st.error(msg)
 
-    if col2.button("Cancel", key=f"cancel_{cadet_id}"):
+    if col2.button("Cancel", key=f"cancel_{cadet_id}", type="secondary"):
         st.session_state.editing_id = None
         st.rerun()
 
@@ -115,21 +117,26 @@ def edit_cadet(cadet):
 def remove_cadet(cadet):
     cadet_id = str(cadet["_id"])
     st.warning(
-        f"Are you sure you want to delete {cadet.get('first_name', '')} {cadet.get('last_name', '')}?"
+        f"Type DELETE below to permanently delete "
+        f"{cadet.get('first_name', '')} {cadet.get('last_name', '')}."
     )
+    confirmation = st.text_input("Confirm delete", key=f"confirm_input_{cadet_id}")
     col1, col2, spacer = st.columns([2, 2, 10])
 
-    if col1.button("Yes", key=f"confirm_{cadet_id}"):
-        result = delete_cadet(cadet_id)
-        if result and result.deleted_count > 0:
-            st.session_state.confirm_delete_id = None
-            st.session_state.success_msg = "Cadet deleted successfully!"
-            st.session_state.success_time = time.time()
-            st.rerun()
+    if col1.button("Confirm Delete", key=f"confirm_{cadet_id}", type="primary"):
+        if confirmation.strip() != "DELETE":
+            st.error("Confirmation text does not match 'DELETE'.")
         else:
-            st.error("Failed to delete cadet.")
+            result = delete_cadet(cadet_id)
+            if result and result.deleted_count > 0:
+                st.session_state.confirm_delete_id = None
+                st.session_state.success_msg = "Cadet deleted successfully!"
+                st.session_state.success_time = time.time()
+                st.rerun()
+            else:
+                st.error("Failed to delete cadet.")
 
-    if col2.button("Cancel", key=f"canceldelete_{cadet_id}"):
+    if col2.button("Cancel", key=f"canceldelete_{cadet_id}", type="secondary"):
         st.session_state.confirm_delete_id = None
         st.rerun()
 
@@ -144,7 +151,7 @@ def show_cadets():
 
     cadets = get_all_cadets()
     if not cadets:
-        st.warning("No cadets found.")
+        st.info("No cadets found.")
         return
 
     if st.session_state.success_time:

--- a/pages/4_Flight_Management.py
+++ b/pages/4_Flight_Management.py
@@ -18,6 +18,11 @@ st.title("Flight Management")
 
 if "confirm_delete_flight_id" not in st.session_state:
     st.session_state.confirm_delete_flight_id = None
+if "_success_msg" not in st.session_state:
+    st.session_state["_success_msg"] = None
+if st.session_state["_success_msg"]:
+    st.success(st.session_state["_success_msg"])
+    st.session_state["_success_msg"] = None
 
 # ----------------------------
 # Create Flight Section
@@ -38,7 +43,7 @@ with st.expander("Create New Flight", expanded=False):
         selected_commander = cadet_display_map.get(selected_display)
         if flight_name and selected_commander:
             create_flight(flight_name, selected_commander)
-            st.success("Flight created successfully!")
+            st.session_state["_success_msg"] = "Flight created successfully!"
             st.rerun()
         else:
             st.warning("Please fill all fields.")
@@ -91,7 +96,7 @@ else:
             if st.button("Assign to Flight", key=f"btn_{flight_id}"):
                 if cadet_to_assign:
                     assign_cadet_to_flight(cadet_to_assign, flight["_id"])
-                    st.success("Cadet assigned.")
+                    st.session_state["_success_msg"] = "Cadet assigned."
                     st.rerun()
 
             st.markdown("**Cadets in this Flight**")
@@ -121,7 +126,7 @@ else:
                     delete_flight(flight["_id"])
                     st.session_state.confirm_delete_flight_id = None
                     st.rerun()
-                if c2.button("Cancel", key=f"cancel_del_{flight_id}"):
+                if c2.button("Cancel", key=f"cancel_del_{flight_id}", type="secondary"):
                     st.session_state.confirm_delete_flight_id = None
                     st.rerun()
             else:

--- a/pages/6_Event_Management_CRUD.py
+++ b/pages/6_Event_Management_CRUD.py
@@ -8,8 +8,14 @@ require_role("admin", "cadre")
 
 if "confirm_delete_event_id" not in st.session_state:
     st.session_state.confirm_delete_event_id = None
+if "_success_msg" not in st.session_state:
+    st.session_state["_success_msg"] = None
 
 st.title("Event Management")
+
+if st.session_state["_success_msg"]:
+    st.success(st.session_state["_success_msg"])
+    st.session_state["_success_msg"] = None
 
 # ── helpers ──────────────────────────────────────────────────────────────────
 
@@ -60,7 +66,7 @@ with st.expander("Event Schedule Configuration", expanded=False):
 
     if st.button("Save Schedule Configuration"):
         if save_event_config(pt_days, llab_days):
-            st.success("Schedule configuration saved!")
+            st.session_state["_success_msg"] = "Schedule configuration saved!"
             config = get_event_config() or {}  # refresh so create form picks it up
             st.rerun()
         else:
@@ -103,7 +109,7 @@ if submitted:
         user = get_current_user()
         user_id = user.get("email", "unknown") if user else "unknown"
         if create_event(event_name.strip(), event_type, start_date, end_date, user_id):
-            st.success(f"Event '{event_name}' created successfully!")
+            st.session_state["_success_msg"] = f"Event '{event_name}' created successfully!"
             st.rerun()
         else:
             st.error("Database unavailable — could not create event.")
@@ -154,11 +160,11 @@ else:
         if c1.button("Yes, delete", type="primary"):
             if delete_event(selected_event["_id"]):
                 st.session_state.confirm_delete_event_id = None
-                st.success("Event deleted.")
+                st.session_state["_success_msg"] = "Event deleted."
                 st.rerun()
             else:
                 st.error("Could not delete event.")
-        if c2.button("Cancel"):
+        if c2.button("Cancel", type="secondary"):
             st.session_state.confirm_delete_event_id = None
             st.rerun()
     else:

--- a/pages/8_User_Management.py
+++ b/pages/8_User_Management.py
@@ -93,13 +93,13 @@ def _render_edit_row(summary: dict[str, str], users: list[dict[str, Any]]) -> No
         else:
             result = update_user(existing_user["_id"], updates)
             if result is not None:
-                st.success("User updated successfully.")
+                st.session_state["_success_msg"] = "User updated successfully."
                 st.session_state["admin_users_editing"] = None
                 st.rerun()
             else:
                 st.error("Failed to update user (database unavailable).")
 
-    if cancel_btn.button("Cancel", key=f"cancel_{user_id}"):
+    if cancel_btn.button("Cancel", key=f"cancel_{user_id}", type="secondary"):
         st.session_state["admin_users_editing"] = None
         st.rerun()
 
@@ -130,14 +130,14 @@ def _render_delete_confirmation(
         else:
             result = delete_user(existing_user["_id"])
             if result is not None:
-                st.success("User deleted successfully.")
+                st.session_state["_success_msg"] = "User deleted successfully."
             else:
                 st.error("Failed to delete user (database unavailable).")
 
         st.session_state["admin_users_confirm_delete"] = None
         st.rerun()
 
-    if cancel_btn.button("Cancel", key=f"cancel_delete_{summary['id']}"):
+    if cancel_btn.button("Cancel", key=f"cancel_delete_{summary['id']}", type="secondary"):
         st.session_state["admin_users_confirm_delete"] = None
         st.rerun()
 
@@ -145,6 +145,12 @@ def _render_delete_confirmation(
 require_role("admin")
 st.title("User Management")
 st.caption("Create, edit, and delete user accounts and roles.")
+
+if "_success_msg" not in st.session_state:
+    st.session_state["_success_msg"] = None
+if st.session_state["_success_msg"]:
+    st.success(st.session_state["_success_msg"])
+    st.session_state["_success_msg"] = None
 
 
 # ----------------------------


### PR DESCRIPTION
Cancel buttons across several pages were missing the `type="secondary"` attribute, causing inconsistent styling.

Pages updated:
- 3_Cadets.py (×2)
- 4_Flight_Management.py (×1)
- 8_User_Management.py (×2)
- 6_Event_Management_CRUD.py (×1)