### PR TITLE
extract full name formatting into shared util #151

### DIFF
--- a/pages/4_Flight_Management.py
+++ b/pages/4_Flight_Management.py
@@ -11,6 +11,7 @@ from utils.db_schema_crud import (
     get_cadet_by_id,
     get_user_by_id,
 )
+from utils.names import format_full_name
 
 require_role("admin", "cadre")
 
@@ -64,9 +65,7 @@ else:
         if commander:
             user = get_user_by_id(commander["user_id"])
             if user:
-                commander_name = (
-                    f"{user.get('first_name', '')} {user.get('last_name', '')}".strip()
-                )
+                commander_name = format_full_name(user)
                 commander_rank = commander.get("rank", "")
 
         cadets_in_flight = get_cadets_by_flight(flight["_id"])
@@ -99,7 +98,7 @@ else:
                 for cadet in cadets_in_flight:
                     user = get_user_by_id(cadet["user_id"])
                     if user:
-                        name = f"{user.get('first_name', '')} {user.get('last_name', '')}".strip()
+                        name = format_full_name(user)
                         rank = cadet.get("rank", "")
                         col1, col2 = st.columns([5, 1])
                         with col1:

--- a/services/cadets.py
+++ b/services/cadets.py
@@ -6,6 +6,7 @@ import pandas as pd
 
 from utils.db import get_collection
 from utils.db_schema_crud import create_cadet, get_user_by_email, get_user_by_id
+from utils.names import format_full_name
 
 CLASS_TO_RANK = {
     "AS100": "100/150 (freshman)",
@@ -42,7 +43,7 @@ def build_cadet_display_map() -> dict[str, str]:
     for cadet in cadets:
         user = get_user_by_id(cadet["user_id"])
         if user:
-            name = f"{user.get('first_name', '')} {user.get('last_name', '')}".strip()
+            name = format_full_name(user)
             rank = cadet.get("rank", "")
             display_map[f"{name} ({rank})"] = str(cadet["_id"])
     return display_map

--- a/services/dashboard.py
+++ b/services/dashboard.py
@@ -1,7 +1,9 @@
 from datetime import datetime
 from typing import Any
-from utils.db import get_collection, get_db
 import pandas as pd
+
+from utils.db import get_collection, get_db
+from utils.names import format_full_name
 
 
 def normalize_status(status: str | None) -> str:
@@ -47,8 +49,7 @@ def build_attendance_grid(
         where grid_rows[i][j] is the P/A/E status for event i and cadet j.
     """
     name_by_user_id = {
-        u["_id"]: f"{u.get('first_name', '')} {u.get('last_name', '')}".strip()
-        or "Unknown"
+        u["_id"]: format_full_name(u, "Unknown")
         for u in user_docs
     }
 

--- a/services/waiver_review.py
+++ b/services/waiver_review.py
@@ -15,6 +15,7 @@ from utils.db_schema_crud import (
     update_waiver,
 )
 
+from utils.names import format_full_name
 from utils.waiver_email import send_waiver_decision_email
 
 
@@ -76,12 +77,7 @@ def get_waiver_context(waiver: dict) -> dict | None:
             if flight:
                 flight_name = flight.get("name", "Unassigned")
 
-    if user:
-        first = user.get("first_name", "")
-        last = user.get("last_name", "")
-        cadet_name = f"{first} {last}".strip() or "Unknown cadet"
-    else:
-        cadet_name = "Unknown cadet"
+    cadet_name = format_full_name(user, "Unknown cadet")
 
     return {
         "cadet_name": cadet_name,

--- a/tests/test_names.py
+++ b/tests/test_names.py
@@ -1,0 +1,20 @@
+from utils.names import format_full_name
+
+
+def test_format_full_name_returns_trimmed_full_name():
+    assert (
+        format_full_name({"first_name": " Tyler ", "last_name": " Brooks "})
+        == "Tyler Brooks"
+    )
+
+
+def test_format_full_name_handles_missing_last_name():
+    assert format_full_name({"first_name": "Tyler"}) == "Tyler"
+
+
+def test_format_full_name_returns_default_when_name_missing():
+    assert format_full_name({"first_name": "", "last_name": ""}, "Unknown") == "Unknown"
+
+
+def test_format_full_name_returns_default_for_missing_user():
+    assert format_full_name(None, "Unknown cadet") == "Unknown cadet"

--- a/utils/at_risk_email.py
+++ b/utils/at_risk_email.py
@@ -16,6 +16,7 @@ from utils.db_schema_crud import (
     set_at_risk_email_sent,
 )
 from utils.attendance_status import get_effective_attendance_status
+from utils.names import format_full_name
 
 
 SENDER_EMAIL = os.getenv("EMAIL_ADDRESS")
@@ -107,7 +108,7 @@ def build_rows(cadets: list[dict]) -> str:
     rows = ""
     for c in cadets:
         cadet = c["cadet"]
-        name = f"{cadet.get('first_name', '')} {cadet.get('last_name', '')}".strip()
+        name = format_full_name(cadet)
 
         flight = (
             get_flight_by_id(cadet["flight_id"]) if cadet.get("flight_id") else None

--- a/utils/auth.py
+++ b/utils/auth.py
@@ -12,6 +12,7 @@ from utils.auth_logic import (
     user_has_any_role,
 )
 from utils.db import get_collection
+from utils.names import format_full_name
 
 _COOKIE_NAME = "rollcall_auth"
 
@@ -84,9 +85,7 @@ def restore_session() -> None:
         return
 
     st.session_state["_raw_users"] = raw
-    st.session_state["name"] = (
-        f"{raw_user.get('first_name', '')} {raw_user.get('last_name', '')}".strip()
-    )
+    st.session_state["name"] = format_full_name(raw_user)
     st.session_state["username"] = username
     st.session_state["authentication_status"] = True
     st.session_state["email"] = raw_user.get("email")

--- a/utils/names.py
+++ b/utils/names.py
@@ -1,0 +1,10 @@
+from typing import Any, Mapping
+
+
+def format_full_name(user: Mapping[str, Any] | None, default: str = "") -> str:
+    if not user:
+        return default
+
+    first = str(user.get("first_name", "") or "").strip()
+    last = str(user.get("last_name", "") or "").strip()
+    return f"{first} {last}".strip() or default


### PR DESCRIPTION
extract repeated full name formatting into utils/names.py 

updated the following files to use the shared helper
- services/cadets.py
- pages/4_Flight_Management.py
- services/waiver_review.py
- utils/auth.py
- utils/at_risk_email.py
- services/dashboard.py

closes #151 