### PR TITLE
implemented flight condensing logic

### DIFF
--- a/pages/10_Commander_Attendance.py
+++ b/pages/10_Commander_Attendance.py
@@ -130,6 +130,7 @@ if st.button("Save All", type="primary"):
             cadet_id=op["cadet_id"],
             status=op["status"],
             recorded_by_user_id=user["_id"],
+            recorded_by_roles=list(user.get("roles", [])),
         )
     st.session_state["_success_msg"] = f"Saved attendance for {len(upserts)} cadet(s)."
     st.rerun()

--- a/pages/2_Attendance_Submission.py
+++ b/pages/2_Attendance_Submission.py
@@ -118,6 +118,7 @@ if (
             cadet_id=cadet_id,
             status="present",
             recorded_by_user_id=user["_id"],
+            recorded_by_roles=list(user.get("roles", [])),
         )
         if result is None:
             st.error("Database unavailable. Could not record attendance.")

--- a/pages/8_Cadet_Attendance.py
+++ b/pages/8_Cadet_Attendance.py
@@ -83,7 +83,9 @@ def show_absence_summary(rows: list[dict]):
     attended_count = sum(
         1 for r in rows if r["status"] in ("present", "excused", "waived")
     )
-    attendance_rate = round(attended_count / total_records * 100) if total_records else 0
+    attendance_rate = (
+        round(attended_count / total_records * 100) if total_records else 0
+    )
 
     col1, col2, col3, col4 = st.columns(4)
     col1.metric("Attendance Rate", f"{attendance_rate}%")

--- a/services/attendance_merge.py
+++ b/services/attendance_merge.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Iterable
+
+try:
+    from bson import ObjectId
+except Exception:  # pragma: no cover
+    ObjectId = None  # type: ignore
+
+
+_HIGH_PRIORITY_ROLES = {"admin", "cadre", "flight_commander"}
+
+
+def _as_utc(dt: datetime) -> datetime:
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _record_time(record: dict[str, Any]) -> datetime:
+    dt = record.get("updated_at") or record.get("created_at")
+    if isinstance(dt, datetime):
+        return _as_utc(dt)
+
+    _id = record.get("_id")
+    if ObjectId is not None and isinstance(_id, ObjectId):
+        # generation_time is timezone-aware UTC
+        return _id.generation_time
+
+    return datetime.min.replace(tzinfo=timezone.utc)
+
+
+def _role_priority(record: dict[str, Any]) -> int:
+    roles = record.get("recorded_by_roles")
+    if not isinstance(roles, Iterable) or isinstance(roles, (str, bytes)):
+        return 0
+
+    normalized = {str(r).strip().lower() for r in roles}
+    return 2 if (normalized & _HIGH_PRIORITY_ROLES) else 1
+
+
+def _pick_best_record(records: list[dict[str, Any]]) -> dict[str, Any]:
+    # Higher role priority wins; then newest timestamp.
+    return max(records, key=lambda r: (_role_priority(r), _record_time(r)))
+
+
+def merge_attendance_records(
+    records: list[dict[str, Any]],
+    *,
+    key_fields: tuple[str, ...] = ("event_id", "cadet_id"),
+) -> list[dict[str, Any]]:
+    """Merge duplicate attendance records deterministically.
+
+    Groups records by the given key_fields and selects a single 'best' record
+    per group.
+
+    Selection rule:
+    1) Records written by higher-privilege roles win (admin/cadre/flight_commander)
+       when the record includes `recorded_by_roles`.
+    2) Ties break by newest `updated_at`/`created_at` (falling back to ObjectId time).
+
+    If `recorded_by_roles` is missing on records, the merge falls back to time only.
+    """
+
+    if not records:
+        return []
+
+    grouped: dict[tuple[Any, ...], list[dict[str, Any]]] = {}
+    for record in records:
+        key = tuple(record.get(f) for f in key_fields)
+        grouped.setdefault(key, []).append(record)
+
+    merged = [_pick_best_record(group) for group in grouped.values()]
+    merged.sort(key=_record_time, reverse=True)
+    return merged

--- a/services/cadet_attendance.py
+++ b/services/cadet_attendance.py
@@ -7,6 +7,7 @@ from utils.db_schema_crud import (
     get_flight_by_id,
 )
 from utils.attendance_status import get_effective_attendance_status
+from services.attendance_merge import merge_attendance_records
 
 
 def load_attendance_db(cadet_id: str) -> tuple[list[dict], list[dict], list[dict]]:
@@ -48,6 +49,7 @@ def cadet_attendance(
     events: list[dict],
     waivers: list[dict],
 ) -> list[dict]:
+    records = merge_attendance_records(records, key_fields=("event_id", "cadet_id"))
     event_map = {e["_id"]: e for e in events}
     waiver_map = {w["attendance_record_id"]: w for w in waivers}
 

--- a/services/commander_attendance.py
+++ b/services/commander_attendance.py
@@ -2,11 +2,17 @@ from __future__ import annotations
 
 from typing import Any
 
+from services.attendance_merge import merge_attendance_records
+
 
 def build_commander_roster(
     flight_cadets: list[dict[str, Any]],
     records: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
+    # Records are expected to be pre-filtered by event in the calling page.
+    # If duplicates exist for a cadet (e.g., multiple submissions), merge
+    # deterministically before building the roster.
+    records = merge_attendance_records(records, key_fields=("cadet_id",))
     record_by_cadet: dict[Any, dict[str, Any]] = {
         r["cadet_id"]: r for r in records if "cadet_id" in r
     }

--- a/services/dashboard.py
+++ b/services/dashboard.py
@@ -48,10 +48,7 @@ def build_attendance_grid(
         (event_row_labels, cadet_name_columns, grid_rows)
         where grid_rows[i][j] is the P/A/E status for event i and cadet j.
     """
-    name_by_user_id = {
-        u["_id"]: format_full_name(u, "Unknown")
-        for u in user_docs
-    }
+    name_by_user_id = {u["_id"]: format_full_name(u, "Unknown") for u in user_docs}
 
     cadet_name_by_id = {
         c["_id"]: name_by_user_id.get(c.get("user_id"), "Unknown") for c in cadet_docs

--- a/services/events.py
+++ b/services/events.py
@@ -14,7 +14,7 @@ def closest_event_index(events: list[dict]) -> int:
             if isinstance(start, datetime):
                 return abs((start.date() - today).days)
             return abs((date.fromisoformat(str(start)[:10]) - today).days)
-        except (ValueError, TypeError):
+        except ValueError, TypeError:
             return 999_999
 
     return min(range(len(events)), key=lambda i: _distance(events[i]))

--- a/tests/test_attendance_merge.py
+++ b/tests/test_attendance_merge.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from bson import ObjectId
+
+import services.cadet_attendance as cadet_attendance_svc
+import services.commander_attendance as commander_attendance_svc
+from services.attendance_merge import merge_attendance_records
+
+
+def test_cadet_attendance_merges_duplicate_records_for_same_event() -> None:
+    """When multiple submissions exist for the same (event, cadet),
+    the UI-facing rows should merge to a single row.
+
+    Expected merge rule (for now): prefer the record with the latest created_at.
+    """
+
+    event_id = ObjectId()
+    cadet_id = ObjectId()
+
+    cadet_record = {
+        "_id": ObjectId(),
+        "event_id": event_id,
+        "cadet_id": cadet_id,
+        "status": "present",
+        "created_at": datetime(2026, 4, 12, 10, 0, tzinfo=timezone.utc),
+        "recorded_by_user_id": ObjectId(),
+        "recorded_by_roles": ["cadet"],
+    }
+    commander_record = {
+        "_id": ObjectId(),
+        "event_id": event_id,
+        "cadet_id": cadet_id,
+        "status": "absent",
+        "created_at": datetime(2026, 4, 12, 9, 0, tzinfo=timezone.utc),
+        "recorded_by_user_id": ObjectId(),
+        "recorded_by_roles": ["flight_commander"],
+    }
+
+    events = [
+        {
+            "_id": event_id,
+            "event_name": "Week 3 PT",
+            "event_type": "pt",
+            "start_date": datetime(2026, 4, 12, 9, 0, tzinfo=timezone.utc),
+            "end_date": datetime(2026, 4, 12, 10, 0, tzinfo=timezone.utc),
+        }
+    ]
+
+    # Order is intentionally adversarial: cadet record first.
+    # Commander should still win even if older.
+    rows = cadet_attendance_svc.cadet_attendance(
+        records=[cadet_record, commander_record],
+        events=events,
+        waivers=[],
+    )
+
+    assert len(rows) == 1
+    assert rows[0]["event_name"] == "Week 3 PT"
+    assert rows[0]["status"] == "absent"
+
+
+def test_build_commander_roster_prefers_latest_record_when_duplicates() -> None:
+    """If duplicates exist in attendance_records (e.g., multiple flight commander submissions),
+    commander roster should resolve them deterministically.
+
+    Expected merge rule (for now): prefer the record with the latest created_at.
+    """
+
+    cadet_id = ObjectId()
+    flight_cadets = [
+        {
+            "_id": cadet_id,
+            "first_name": "Alex",
+            "last_name": "Cadet",
+        }
+    ]
+
+    older = {
+        "_id": ObjectId(),
+        "event_id": ObjectId(),
+        "cadet_id": cadet_id,
+        "status": "present",
+        "created_at": datetime(2026, 4, 12, 9, 0, tzinfo=timezone.utc),
+        "recorded_by_user_id": ObjectId(),
+        "recorded_by_roles": ["flight_commander"],
+    }
+    newer = {
+        "_id": ObjectId(),
+        "event_id": older["event_id"],
+        "cadet_id": cadet_id,
+        "status": "absent",
+        "created_at": datetime(2026, 4, 12, 10, 0, tzinfo=timezone.utc),
+        "recorded_by_user_id": ObjectId(),
+        "recorded_by_roles": ["flight_commander"],
+    }
+
+    # Adversarial order: older record comes last.
+    roster = commander_attendance_svc.build_commander_roster(
+        flight_cadets=flight_cadets,
+        records=[newer, older],
+    )
+
+    assert len(roster) == 1
+    assert roster[0]["cadet"]["_id"] == cadet_id
+    assert roster[0]["current_status"] == "absent"
+
+
+def test_merge_prefers_high_priority_roles_over_cadet_even_if_older() -> None:
+    event_id = ObjectId()
+    cadet_id = ObjectId()
+
+    cadet_record = {
+        "_id": ObjectId(),
+        "event_id": event_id,
+        "cadet_id": cadet_id,
+        "status": "present",
+        "created_at": datetime(2026, 4, 12, 10, 0, tzinfo=timezone.utc),
+        "recorded_by_roles": ["cadet"],
+    }
+    commander_record = {
+        "_id": ObjectId(),
+        "event_id": event_id,
+        "cadet_id": cadet_id,
+        "status": "absent",
+        "created_at": datetime(2026, 4, 12, 9, 0, tzinfo=timezone.utc),
+        "recorded_by_roles": ["flight_commander"],
+    }
+
+    merged = merge_attendance_records([cadet_record, commander_record])
+    assert len(merged) == 1
+    assert merged[0]["status"] == "absent"
+
+
+def test_merge_tie_breaks_by_time_when_both_high_priority() -> None:
+    event_id = ObjectId()
+    cadet_id = ObjectId()
+
+    older_cadre = {
+        "_id": ObjectId(),
+        "event_id": event_id,
+        "cadet_id": cadet_id,
+        "status": "present",
+        "created_at": datetime(2026, 4, 12, 9, 0, tzinfo=timezone.utc),
+        "recorded_by_roles": ["cadre"],
+    }
+    newer_commander = {
+        "_id": ObjectId(),
+        "event_id": event_id,
+        "cadet_id": cadet_id,
+        "status": "absent",
+        "created_at": datetime(2026, 4, 12, 10, 0, tzinfo=timezone.utc),
+        "recorded_by_roles": ["flight_commander"],
+    }
+
+    merged = merge_attendance_records([older_cadre, newer_commander])
+    assert len(merged) == 1
+    assert merged[0]["status"] == "absent"
+
+
+def test_merge_falls_back_to_newest_time_when_roles_missing() -> None:
+    event_id = ObjectId()
+    cadet_id = ObjectId()
+
+    older = {
+        "_id": ObjectId(),
+        "event_id": event_id,
+        "cadet_id": cadet_id,
+        "status": "present",
+        "created_at": datetime(2026, 4, 12, 9, 0, tzinfo=timezone.utc),
+    }
+    newer = {
+        "_id": ObjectId(),
+        "event_id": event_id,
+        "cadet_id": cadet_id,
+        "status": "absent",
+        "created_at": datetime(2026, 4, 12, 10, 0, tzinfo=timezone.utc),
+    }
+
+    merged = merge_attendance_records([older, newer])
+    assert len(merged) == 1
+    assert merged[0]["status"] == "absent"
+
+
+def test_merge_does_not_merge_across_events() -> None:
+    cadet_id = ObjectId()
+    event_a = ObjectId()
+    event_b = ObjectId()
+
+    rec_a = {
+        "_id": ObjectId(),
+        "event_id": event_a,
+        "cadet_id": cadet_id,
+        "status": "present",
+        "created_at": datetime(2026, 4, 12, 9, 0, tzinfo=timezone.utc),
+        "recorded_by_roles": ["cadet"],
+    }
+    rec_b = {
+        "_id": ObjectId(),
+        "event_id": event_b,
+        "cadet_id": cadet_id,
+        "status": "absent",
+        "created_at": datetime(2026, 4, 13, 9, 0, tzinfo=timezone.utc),
+        "recorded_by_roles": ["cadet"],
+    }
+
+    merged = merge_attendance_records([rec_a, rec_b])
+    assert len(merged) == 2
+    assert {r["event_id"] for r in merged} == {event_a, event_b}

--- a/utils/auth.py
+++ b/utils/auth.py
@@ -68,7 +68,7 @@ def restore_session() -> None:
     assert AUTH_COOKIE_KEY is not None
     try:
         token = jwt.decode(raw_token, AUTH_COOKIE_KEY, algorithms=["HS256"])
-    except (DecodeError, InvalidSignatureError):
+    except DecodeError, InvalidSignatureError:
         return
 
     username = token.get("username")

--- a/utils/auth.py
+++ b/utils/auth.py
@@ -68,7 +68,7 @@ def restore_session() -> None:
     assert AUTH_COOKIE_KEY is not None
     try:
         token = jwt.decode(raw_token, AUTH_COOKIE_KEY, algorithms=["HS256"])
-    except DecodeError, InvalidSignatureError:
+    except (DecodeError, InvalidSignatureError):
         return
 
     username = token.get("username")

--- a/utils/db_schema_crud.py
+++ b/utils/db_schema_crud.py
@@ -52,13 +52,6 @@ def get_users_by_role(role: str) -> list[dict]:
     return list(col.find({"roles": role}))
 
 
-def get_users_by_role(role: str) -> list[dict]:
-    col = get_collection("users")
-    if col is None:
-        return []
-    return list(col.find({"roles": role}))
-
-
 def update_user(user_id: str | ObjectId, updates: dict) -> UpdateResult | None:
     col = get_collection("users")
     if col is None:
@@ -303,19 +296,21 @@ def create_attendance_record(
     cadet_id: str | ObjectId,
     status: str,
     recorded_by_user_id: str | ObjectId,
+    recorded_by_roles: list[str] | None = None,
 ) -> InsertOneResult | None:
     col = get_collection("attendance_records")
     if col is None:
         return None
-    return col.insert_one(
-        {
-            "event_id": ObjectId(event_id),
-            "cadet_id": ObjectId(cadet_id),
-            "status": status,
-            "recorded_by_user_id": ObjectId(recorded_by_user_id),
-            "created_at": datetime.now(timezone.utc),
-        }
-    )
+    doc = {
+        "event_id": ObjectId(event_id),
+        "cadet_id": ObjectId(cadet_id),
+        "status": status,
+        "recorded_by_user_id": ObjectId(recorded_by_user_id),
+        "created_at": datetime.now(timezone.utc),
+    }
+    if recorded_by_roles is not None:
+        doc["recorded_by_roles"] = list(recorded_by_roles)
+    return col.insert_one(doc)
 
 
 def get_attendance_record_by_id(record_id: str | ObjectId) -> dict | None:
@@ -344,6 +339,7 @@ def upsert_attendance_record(
     cadet_id: str | ObjectId,
     status: str,
     recorded_by_user_id: str | ObjectId,
+    recorded_by_roles: list[str] | None = None,
 ) -> UpdateResult | None:
     """Insert or update a single attendance record atomically.
 
@@ -353,16 +349,20 @@ def upsert_attendance_record(
     col = get_collection("attendance_records")
     if col is None:
         return None
+    set_doc = {
+        "status": status,
+        "recorded_by_user_id": ObjectId(recorded_by_user_id),
+        "updated_at": datetime.now(timezone.utc),
+    }
+    if recorded_by_roles is not None:
+        set_doc["recorded_by_roles"] = list(recorded_by_roles)
     return col.update_one(
         {
             "event_id": ObjectId(event_id),
             "cadet_id": ObjectId(cadet_id),
         },
         {
-            "$set": {
-                "status": status,
-                "recorded_by_user_id": ObjectId(recorded_by_user_id),
-            },
+            "$set": set_doc,
             "$setOnInsert": {
                 "created_at": datetime.now(timezone.utc),
             },


### PR DESCRIPTION
closes #22 

Condense duplicate attendance submissions into one unified result per cadet per event.

Deterministic rule, higher roles on duplicate attendance logs overrider lower (example: flight commander's attendance submission will override a cadets)

Applies merge to cadet attendance rows + commander roster so duplicates don’t show multiple rows or random statuses.

