### PR TITLE
Improve modifying attendance and flight management

### DIFF
--- a/pages/10_Commander_Attendance.py
+++ b/pages/10_Commander_Attendance.py
@@ -9,6 +9,10 @@ import streamlit as st
 from services.commander_attendance import build_commander_roster, compute_upserts
 from services.events import closest_event_index, get_all_events
 from utils.auth import get_current_user, require_role
+from utils.attendance_status import (
+    get_attendance_status_cell_style,
+    get_attendance_status_label,
+)
 from utils.db_schema_crud import (
     get_all_cadets,
     get_attendance_by_event,
@@ -19,7 +23,6 @@ from utils.db_schema_crud import (
 
 STATUS_OPTIONS = ["Present", "Absent", "Excused"]
 STATUS_TO_DB = {"Present": "present", "Absent": "absent", "Excused": "excused"}
-DB_TO_STATUS = {"present": "Present", "absent": "Absent", "excused": "Excused"}
 
 require_role("admin", "cadre")
 st.title("Modify Attendance")
@@ -101,15 +104,32 @@ df = pd.DataFrame(
             or "Unknown"
             for e in roster
         ],
-        "Status": [DB_TO_STATUS.get(e["current_status"], "Present") for e in roster],
+        "Current Status": [
+            get_attendance_status_label(e["current_status"], default="Present")
+            for e in roster
+        ],
+        "Set Status": [
+            get_attendance_status_label(e["current_status"], default="Present")
+            for e in roster
+        ],
     }
 )
 
+styler = df.style
+if hasattr(styler, "map"):
+    styler = styler.map(get_attendance_status_cell_style, subset=["Current Status"])
+else:
+    styler = styler.applymap(
+        get_attendance_status_cell_style,
+        subset=["Current Status"],
+    )
+
 edited = st.data_editor(
-    df,
+    styler,
     column_config={
         "Cadet": st.column_config.TextColumn(disabled=True),
-        "Status": st.column_config.SelectboxColumn(
+        "Current Status": st.column_config.TextColumn(disabled=True),
+        "Set Status": st.column_config.SelectboxColumn(
             options=STATUS_OPTIONS, required=True
         ),
     },
@@ -120,7 +140,7 @@ edited = st.data_editor(
 st.divider()
 if st.button("Save All", type="primary"):
     new_statuses = {
-        cadet_ids[idx]: STATUS_TO_DB[row["Status"]]
+        cadet_ids[idx]: STATUS_TO_DB[row["Set Status"]]
         for idx, (_, row) in enumerate(edited.iterrows())
     }
     upserts = compute_upserts(roster, new_statuses)

--- a/pages/10_Commander_Attendance.py
+++ b/pages/10_Commander_Attendance.py
@@ -7,9 +7,10 @@ import pandas as pd
 import streamlit as st
 
 from services.commander_attendance import build_commander_roster, compute_upserts
-from services.events import closest_event_index, get_all_events
+from services.events import closest_event_index, get_all_events, has_event_ended
 from utils.auth import get_current_user, require_role
 from utils.attendance_status import (
+    NO_RECORD_STATUS_LABEL,
     get_attendance_status_cell_style,
     get_attendance_status_label,
 )
@@ -21,7 +22,7 @@ from utils.db_schema_crud import (
     upsert_attendance_record,
 )
 
-STATUS_OPTIONS = ["Present", "Absent", "Excused"]
+STATUS_OPTIONS = [NO_RECORD_STATUS_LABEL, "Present", "Absent", "Excused"]
 STATUS_TO_DB = {"Present": "present", "Absent": "absent", "Excused": "excused"}
 
 require_role("admin", "cadre")
@@ -72,6 +73,8 @@ if selected_event is None:
     st.stop()
 
 event_id: str = selected_event["_id"]
+event_has_ended = has_event_ended(selected_event)
+default_status = "Absent" if event_has_ended else NO_RECORD_STATUS_LABEL
 
 all_cadets = get_all_cadets()
 if not all_cadets:
@@ -95,6 +98,10 @@ records = get_attendance_by_event(event_id)
 roster = build_commander_roster(all_cadets, records)
 
 cadet_ids = [str(entry["cadet"]["_id"]) for entry in roster]
+initial_statuses = [
+    get_attendance_status_label(entry["current_status"], default=default_status)
+    for entry in roster
+]
 
 df = pd.DataFrame(
     {
@@ -104,14 +111,8 @@ df = pd.DataFrame(
             or "Unknown"
             for e in roster
         ],
-        "Current Status": [
-            get_attendance_status_label(e["current_status"], default="Present")
-            for e in roster
-        ],
-        "Set Status": [
-            get_attendance_status_label(e["current_status"], default="Present")
-            for e in roster
-        ],
+        "Current Status": initial_statuses,
+        "Set Status": initial_statuses,
     }
 )
 
@@ -139,9 +140,22 @@ edited = st.data_editor(
 
 st.divider()
 if st.button("Save All", type="primary"):
+    invalid_no_record_rows = [
+        roster[idx]["cadet"]
+        for idx, (_, row) in enumerate(edited.iterrows())
+        if row["Set Status"] == NO_RECORD_STATUS_LABEL and roster[idx]["record"] is not None
+    ]
+    if invalid_no_record_rows:
+        st.error(
+            "No Record can only be used for cadets who do not already have an attendance entry."
+        )
+        st.stop()
+
     new_statuses = {
         cadet_ids[idx]: STATUS_TO_DB[row["Set Status"]]
         for idx, (_, row) in enumerate(edited.iterrows())
+        if row["Set Status"] != initial_statuses[idx]
+        and row["Set Status"] in STATUS_TO_DB
     }
     upserts = compute_upserts(roster, new_statuses)
     for op in upserts:

--- a/pages/1_Dashboard.py
+++ b/pages/1_Dashboard.py
@@ -10,6 +10,10 @@ from bson import ObjectId
 
 from services.events import closest_event_index
 from utils.auth import get_current_user, require_role
+from utils.attendance_status import (
+    get_attendance_status_cell_style,
+    get_attendance_status_label,
+)
 from utils.db import get_collection, get_db
 from utils.export import to_excel
 
@@ -23,14 +27,7 @@ def _utc_datetime(d: date, end_of_day: bool) -> datetime:
 
 
 def _status_bucket(raw: str | None) -> str:
-    s = (raw or "").strip().lower()
-    if s == "present":
-        return "Present"
-    if s == "absent":
-        return "Absent"
-    if s in {"excused", "waived"}:
-        return "Excused"
-    return "Absent"
+    return get_attendance_status_label(raw, default="Absent")
 
 
 def _format_name(user_doc: dict[str, Any] | None) -> str:
@@ -49,20 +46,6 @@ def _event_label(event_doc: dict[str, Any]) -> str:
     ev_type = str(event_doc.get("event_type", "") or "").upper()
     left = f"{ev_date} — {ev_name}".strip(" —")
     return f"{left} ({ev_type})".strip()
-
-
-def _status_cell_style(val: Any) -> str:
-    """Return CSS style for a Status cell."""
-    s = str(val or "")
-    if s == "Present":
-        return "background-color: #7FE08A; color: #0b2e13; font-weight: 700;"
-    if s == "Absent":
-        return "background-color: #E07F7F; color: #2b0b0b; font-weight: 700;"
-    if s == "Excused":
-        return "background-color: #E0D27F; color: #2b240b; font-weight: 700;"
-    return ""
-
-
 require_role("admin", "cadre", "flight_commander")
 
 st.title("Dashboard")
@@ -350,9 +333,15 @@ else:
                     cadet_df = pd.DataFrame(cadet_rows)
                     styler = cadet_df.style
                     if hasattr(styler, "map"):
-                        styler = styler.map(_status_cell_style, subset=["Status"])
+                        styler = styler.map(
+                            get_attendance_status_cell_style,
+                            subset=["Status"],
+                        )
                     else:
-                        styler = styler.applymap(_status_cell_style, subset=["Status"])
+                        styler = styler.applymap(
+                            get_attendance_status_cell_style,
+                            subset=["Status"],
+                        )
 
                     col1, col2, spacer = st.columns([1.5, 2, 10])
                     if isinstance(cadet_df, pd.DataFrame):

--- a/pages/4_Flight_Management.py
+++ b/pages/4_Flight_Management.py
@@ -39,9 +39,12 @@ with st.expander("Create New Flight", expanded=False):
     if submitted:
         selected_commander = cadet_display_map.get(selected_display)
         if flight_name and selected_commander:
-            create_flight(flight_name, selected_commander)
-            st.success("Flight created successfully!")
-            st.rerun()
+            try:
+                create_flight(flight_name, selected_commander)
+                st.success("Flight created successfully!")
+                st.rerun()
+            except ValueError as e:
+                st.error(str(e))
         else:
             st.warning("Please fill all fields.")
 

--- a/pages/4_Flight_Management.py
+++ b/pages/4_Flight_Management.py
@@ -1,12 +1,16 @@
 import streamlit as st
 
 from utils.auth import require_role
-from services.cadets import build_cadet_display_map, get_cadets_by_flight
+from services.cadets import (
+    assign_cadet_to_flight,
+    build_cadet_display_map,
+    get_assignable_cadet_display_map,
+    get_cadets_by_flight,
+)
 from utils.db_schema_crud import (
     create_flight,
     delete_flight,
     get_all_flights,
-    assign_cadet_to_flight,
     unassign_cadet_from_flight,
     unassign_all_cadets_from_flight,
     get_cadet_by_id,
@@ -20,6 +24,19 @@ st.title("Flight Management")
 
 if "confirm_delete_flight_id" not in st.session_state:
     st.session_state.confirm_delete_flight_id = None
+if "flight_feedback" not in st.session_state:
+    st.session_state.flight_feedback = None
+if "expanded_flight_id" not in st.session_state:
+    st.session_state.expanded_flight_id = None
+
+
+def set_flight_feedback(flight_id: str, level: str, message: str) -> None:
+    st.session_state.flight_feedback = {
+        "flight_id": flight_id,
+        "level": level,
+        "message": message,
+    }
+    st.session_state.expanded_flight_id = flight_id
 
 # ----------------------------
 # Create Flight Section
@@ -55,6 +72,8 @@ st.divider()
 # ----------------------------
 
 flights = get_all_flights()
+assignable_cadet_display_map = get_assignable_cadet_display_map()
+rendered_feedback = False
 
 if not flights:
     st.info("No flights created yet.")
@@ -76,29 +95,58 @@ else:
         cadet_count = len(cadets_in_flight)
 
         with st.expander(
-            f"{flight['name']}  ·  Commander: {commander_name}  ·  {cadet_count} cadet(s)"
+            f"{flight['name']}  ·  Commander: {commander_name}  ·  {cadet_count} cadet(s)",
+            expanded=(
+                st.session_state.expanded_flight_id == flight_id
+                or st.session_state.confirm_delete_flight_id == flight_id
+            ),
         ):
+            feedback = st.session_state.flight_feedback
+            if feedback and feedback.get("flight_id") == flight_id:
+                level = feedback.get("level")
+                message = feedback.get("message")
+                if level == "success":
+                    st.success(message)
+                elif level == "warning":
+                    st.warning(message)
+                else:
+                    st.error(message)
+                rendered_feedback = True
+
             st.caption(
                 f"Commander: {commander_name}"
                 + (f" ({commander_rank})" if commander_rank else "")
             )
 
             st.markdown("**Assign / Reassign Cadet**")
-            cadet_to_assign_display = st.selectbox(
-                "Select cadet",
-                options=list(cadet_display_map.keys()),
-                key=f"assign_{flight_id}",
-                label_visibility="collapsed",
-            )
-            cadet_to_assign = cadet_display_map.get(cadet_to_assign_display)
-            if st.button("Assign to Flight", key=f"btn_{flight_id}"):
+            cadet_to_assign = None
+            if assignable_cadet_display_map:
+                cadet_to_assign_display = st.selectbox(
+                    "Select cadet",
+                    options=list(assignable_cadet_display_map.keys()),
+                    key=f"assign_{flight_id}",
+                    label_visibility="collapsed",
+                )
+                cadet_to_assign = assignable_cadet_display_map.get(cadet_to_assign_display)
+                assign_clicked = st.button("Assign to Flight", key=f"btn_{flight_id}")
+            else:
+                st.caption("No assignable cadets are available.")
+                assign_clicked = st.button(
+                    "Assign to Flight",
+                    key=f"btn_{flight_id}",
+                    disabled=True,
+                )
+
+            if assign_clicked:
+                st.session_state.expanded_flight_id = flight_id
                 if cadet_to_assign:
                     try:
                         assign_cadet_to_flight(cadet_to_assign, flight["_id"])
-                        st.success("Cadet assigned.")
+                        set_flight_feedback(flight_id, "success", "Cadet assigned.")
                         st.rerun()
                     except ValueError as e:
-                        st.error(str(e))
+                        set_flight_feedback(flight_id, "error", str(e))
+                        st.rerun()
 
             st.markdown("**Cadets in this Flight**")
             if cadets_in_flight:
@@ -113,6 +161,11 @@ else:
                         with col2:
                             if st.button("Unassign", key=f"unassign_{cadet['_id']}"):
                                 unassign_cadet_from_flight(cadet["_id"])
+                                set_flight_feedback(
+                                    flight_id,
+                                    "success",
+                                    "Cadet unassigned.",
+                                )
                                 st.rerun()
             else:
                 st.caption("No cadets assigned yet.")
@@ -148,4 +201,8 @@ else:
             else:
                 if st.button("Delete Flight", key=f"delete_{flight_id}"):
                     st.session_state.confirm_delete_flight_id = flight_id
+                    st.session_state.expanded_flight_id = flight_id
                     st.rerun()
+
+if rendered_feedback:
+    st.session_state.flight_feedback = None

--- a/pages/4_Flight_Management.py
+++ b/pages/4_Flight_Management.py
@@ -24,10 +24,24 @@ st.title("Flight Management")
 
 if "confirm_delete_flight_id" not in st.session_state:
     st.session_state.confirm_delete_flight_id = None
+if "create_flight_success" not in st.session_state:
+    st.session_state.create_flight_success = None
 if "flight_feedback" not in st.session_state:
     st.session_state.flight_feedback = None
-if "expanded_flight_id" not in st.session_state:
-    st.session_state.expanded_flight_id = None
+if "expanded_flight_ids" not in st.session_state:
+    st.session_state.expanded_flight_ids = []
+
+
+def keep_flight_expanded(flight_id: str) -> None:
+    expanded_ids = set(st.session_state.expanded_flight_ids)
+    expanded_ids.add(flight_id)
+    st.session_state.expanded_flight_ids = sorted(expanded_ids)
+
+
+def forget_flight_expanded(flight_id: str) -> None:
+    expanded_ids = set(st.session_state.expanded_flight_ids)
+    expanded_ids.discard(flight_id)
+    st.session_state.expanded_flight_ids = sorted(expanded_ids)
 
 
 def set_flight_feedback(flight_id: str, level: str, message: str) -> None:
@@ -36,7 +50,7 @@ def set_flight_feedback(flight_id: str, level: str, message: str) -> None:
         "level": level,
         "message": message,
     }
-    st.session_state.expanded_flight_id = flight_id
+    keep_flight_expanded(flight_id)
 
 # ----------------------------
 # Create Flight Section
@@ -58,12 +72,16 @@ with st.expander("Create New Flight", expanded=False):
         if flight_name and selected_commander:
             try:
                 create_flight(flight_name, selected_commander)
-                st.success("Flight created successfully!")
+                st.session_state.create_flight_success = "Flight created successfully!"
                 st.rerun()
             except ValueError as e:
                 st.error(str(e))
         else:
             st.warning("Please fill all fields.")
+
+if st.session_state.create_flight_success:
+    st.success(st.session_state.create_flight_success)
+    st.session_state.create_flight_success = None
 
 st.divider()
 
@@ -94,13 +112,20 @@ else:
         cadets_in_flight = get_cadets_by_flight(flight["_id"])
         cadet_count = len(cadets_in_flight)
 
-        with st.expander(
-            f"{flight['name']}  ·  Commander: {commander_name}  ·  {cadet_count} cadet(s)",
-            expanded=(
-                st.session_state.expanded_flight_id == flight_id
-                or st.session_state.confirm_delete_flight_id == flight_id
-            ),
-        ):
+        expander_label = (
+            f"{flight['name']}  ·  Commander: {commander_name}  ·  {cadet_count} cadet(s)"
+        )
+        force_expanded = (
+            flight_id in st.session_state.expanded_flight_ids
+            or st.session_state.confirm_delete_flight_id == flight_id
+        )
+
+        if force_expanded:
+            expander = st.expander(expander_label, expanded=True)
+        else:
+            expander = st.expander(expander_label)
+
+        with expander:
             feedback = st.session_state.flight_feedback
             if feedback and feedback.get("flight_id") == flight_id:
                 level = feedback.get("level")
@@ -138,7 +163,7 @@ else:
                 )
 
             if assign_clicked:
-                st.session_state.expanded_flight_id = flight_id
+                keep_flight_expanded(flight_id)
                 if cadet_to_assign:
                     try:
                         assign_cadet_to_flight(cadet_to_assign, flight["_id"])
@@ -194,14 +219,16 @@ else:
                         unassign_all_cadets_from_flight(flight["_id"])
                         delete_flight(flight["_id"])
                         st.session_state.confirm_delete_flight_id = None
+                        forget_flight_expanded(flight_id)
                         st.rerun()
                 if c2.button("Cancel", key=f"cancel_del_{flight_id}"):
                     st.session_state.confirm_delete_flight_id = None
+                    keep_flight_expanded(flight_id)
                     st.rerun()
             else:
                 if st.button("Delete Flight", key=f"delete_{flight_id}"):
                     st.session_state.confirm_delete_flight_id = flight_id
-                    st.session_state.expanded_flight_id = flight_id
+                    keep_flight_expanded(flight_id)
                     st.rerun()
 
 if rendered_feedback:

--- a/pages/6_Event_Management_CRUD.py
+++ b/pages/6_Event_Management_CRUD.py
@@ -8,6 +8,8 @@ require_role("admin", "cadre")
 
 if "confirm_delete_event_id" not in st.session_state:
     st.session_state.confirm_delete_event_id = None
+if "create_event_success" not in st.session_state:
+    st.session_state.create_event_success = None
 
 st.title("Event Management")
 
@@ -103,10 +105,16 @@ if submitted:
         user = get_current_user()
         user_id = user.get("email", "unknown") if user else "unknown"
         if create_event(event_name.strip(), event_type, start_date, end_date, user_id):
-            st.success(f"Event '{event_name}' created successfully!")
+            st.session_state.create_event_success = (
+                f"Event '{event_name.strip()}' created successfully!"
+            )
             st.rerun()
         else:
             st.error("Database unavailable — could not create event.")
+
+if st.session_state.create_event_success:
+    st.success(st.session_state.create_event_success)
+    st.session_state.create_event_success = None
 
 st.divider()
 

--- a/services/cadets.py
+++ b/services/cadets.py
@@ -5,7 +5,13 @@ import secrets
 import pandas as pd
 
 from utils.db import get_collection
-from utils.db_schema_crud import create_cadet, get_user_by_email, get_user_by_id
+from utils.db_schema_crud import (
+    assign_cadet_to_flight as db_assign_cadet_to_flight,
+    create_cadet,
+    get_cadet_by_id,
+    get_user_by_email,
+    get_user_by_id,
+)
 from utils.names import format_full_name
 
 CLASS_TO_RANK = {
@@ -30,10 +36,46 @@ def get_all_cadets() -> list[dict]:
 
 
 def get_cadets_by_flight(flight_id) -> list[dict]:
-    col = get_collection("cadets")
-    if col is None:
+    cadets_col = get_collection("cadets")
+    flights_col = get_collection("flights")
+    if cadets_col is None:
         return []
-    return list(col.find({"flight_id": ObjectId(flight_id)}))
+
+    cadets = list(cadets_col.find({"flight_id": ObjectId(flight_id)}))
+    if flights_col is None:
+        return cadets
+
+    flight = flights_col.find_one({"_id": ObjectId(flight_id)})
+    if not flight or not flight.get("commander_cadet_id"):
+        return cadets
+
+    return [cadet for cadet in cadets if cadet["_id"] != flight["commander_cadet_id"]]
+
+
+def get_assignable_cadet_display_map() -> dict[str, str]:
+    flights_col = get_collection("flights")
+    if flights_col is None:
+        return build_cadet_display_map()
+
+    commander_cadet_ids = {
+        str(flight["commander_cadet_id"])
+        for flight in flights_col.find({}, {"commander_cadet_id": 1})
+        if flight.get("commander_cadet_id")
+    }
+
+    return {
+        display: cadet_id
+        for display, cadet_id in build_cadet_display_map().items()
+        if cadet_id not in commander_cadet_ids
+    }
+
+
+def assign_cadet_to_flight(cadet_id, flight_id):
+    cadet = get_cadet_by_id(cadet_id)
+    if cadet and cadet.get("flight_id") == ObjectId(flight_id):
+        raise ValueError("Cadet is already in this flight.")
+
+    return db_assign_cadet_to_flight(cadet_id, flight_id)
 
 
 def build_cadet_display_map() -> dict[str, str]:

--- a/services/commander_attendance.py
+++ b/services/commander_attendance.py
@@ -50,6 +50,8 @@ def compute_upserts(
 
         record = entry["record"]
         if record is not None:
+            if entry.get("current_status") == new_status:
+                continue
             upserts.append(
                 {
                     "action": "update",

--- a/services/events.py
+++ b/services/events.py
@@ -1,4 +1,5 @@
 from datetime import date, datetime, timezone
+from typing import Any
 from bson import ObjectId
 from utils.db import get_db
 
@@ -18,6 +19,28 @@ def closest_event_index(events: list[dict]) -> int:
             return 999_999
 
     return min(range(len(events)), key=lambda i: _distance(events[i]))
+
+
+def has_event_ended(
+    event: dict[str, Any] | None,
+    *,
+    now: datetime | None = None,
+) -> bool:
+    if not event:
+        return False
+
+    end_at = event.get("end_date") or event.get("start_date")
+    if not isinstance(end_at, datetime):
+        return False
+
+    if end_at.tzinfo is None:
+        end_at = end_at.replace(tzinfo=timezone.utc)
+
+    current_time = now or datetime.now(timezone.utc)
+    if current_time.tzinfo is None:
+        current_time = current_time.replace(tzinfo=timezone.utc)
+
+    return current_time > end_at
 
 
 def get_all_events() -> list[dict]:

--- a/tests/test_attendance_status.py
+++ b/tests/test_attendance_status.py
@@ -1,4 +1,5 @@
 from utils.attendance_status import (
+    NO_RECORD_STATUS_LABEL,
     get_attendance_status_cell_style,
     get_attendance_status_label,
     get_effective_attendance_status,
@@ -15,6 +16,17 @@ def test_attendance_status_label_maps_waived_to_excused():
 
 def test_attendance_status_label_uses_default_for_unknown_status():
     assert get_attendance_status_label("unknown", default="Absent") == "Absent"
+
+
+def test_attendance_status_label_uses_no_record_default_for_missing_status():
+    assert get_attendance_status_label(None, default=NO_RECORD_STATUS_LABEL) == NO_RECORD_STATUS_LABEL
+
+
+def test_attendance_status_cell_style_matches_no_record():
+    style = get_attendance_status_cell_style(NO_RECORD_STATUS_LABEL)
+
+    assert "background-color: #D9DDE6" in style
+    assert "font-weight: 700" in style
 
 
 def test_attendance_status_cell_style_matches_present():

--- a/tests/test_attendance_status.py
+++ b/tests/test_attendance_status.py
@@ -1,0 +1,35 @@
+from utils.attendance_status import (
+    get_attendance_status_cell_style,
+    get_attendance_status_label,
+    get_effective_attendance_status,
+)
+
+
+def test_effective_attendance_status_marks_approved_absence_as_waived():
+    assert get_effective_attendance_status("absent", "approved") == "waived"
+
+
+def test_attendance_status_label_maps_waived_to_excused():
+    assert get_attendance_status_label("absent", "approved") == "Excused"
+
+
+def test_attendance_status_label_uses_default_for_unknown_status():
+    assert get_attendance_status_label("unknown", default="Absent") == "Absent"
+
+
+def test_attendance_status_cell_style_matches_present():
+    style = get_attendance_status_cell_style("Present")
+
+    assert "background-color: #7FE08A" in style
+    assert "font-weight: 700" in style
+
+
+def test_attendance_status_cell_style_matches_absent():
+    style = get_attendance_status_cell_style("Absent")
+
+    assert "background-color: #E07F7F" in style
+    assert "font-weight: 700" in style
+
+
+def test_attendance_status_cell_style_returns_empty_for_unknown_status():
+    assert get_attendance_status_cell_style("Unknown") == ""

--- a/tests/test_commander_attendance.py
+++ b/tests/test_commander_attendance.py
@@ -109,6 +109,18 @@ def test_upsert_updates_record_when_one_exists():
     assert upserts[0]["status"] == "absent"
 
 
+def test_upsert_skips_unchanged_existing_record():
+    roster = [
+        {
+            "cadet": {"_id": "c1"},
+            "record": {"_id": "r1", "status": "present"},
+            "current_status": "present",
+        }
+    ]
+
+    assert compute_upserts(roster, {"c1": "present"}) == []
+
+
 def test_upsert_commander_wins_over_existing_status():
     roster = [
         {

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,38 @@
+from datetime import datetime, timezone
+
+from services.events import has_event_ended
+
+
+def test_has_event_ended_uses_end_date_when_present() -> None:
+    event = {
+        "start_date": datetime(2026, 4, 21, 10, 0, tzinfo=timezone.utc),
+        "end_date": datetime(2026, 4, 21, 11, 0, tzinfo=timezone.utc),
+    }
+
+    assert has_event_ended(
+        event,
+        now=datetime(2026, 4, 21, 11, 1, tzinfo=timezone.utc),
+    )
+
+
+def test_has_event_ended_falls_back_to_start_date() -> None:
+    event = {
+        "start_date": datetime(2026, 4, 21, 10, 0, tzinfo=timezone.utc),
+    }
+
+    assert has_event_ended(
+        event,
+        now=datetime(2026, 4, 21, 10, 1, tzinfo=timezone.utc),
+    )
+
+
+def test_has_event_ended_is_false_before_end_time() -> None:
+    event = {
+        "start_date": datetime(2026, 4, 21, 10, 0, tzinfo=timezone.utc),
+        "end_date": datetime(2026, 4, 21, 11, 0, tzinfo=timezone.utc),
+    }
+
+    assert not has_event_ended(
+        event,
+        now=datetime(2026, 4, 21, 10, 59, tzinfo=timezone.utc),
+    )

--- a/tests/test_flight_management.py
+++ b/tests/test_flight_management.py
@@ -8,6 +8,7 @@ from utils.db_schema_crud import (
     assign_cadet_to_flight,
     unassign_all_cadets_from_flight,
 )
+from services.cadets import assign_cadet_to_flight as assign_cadet_to_flight_service
 
 
 @patch("utils.db_schema_crud.get_collection")
@@ -68,9 +69,14 @@ def test_assign_cadet_to_flight_raises_if_already_in_different_flight(
         "_id": cadet_id,
         "flight_id": existing_flight_id,
     }
-    flights_collection.find_one.return_value = None
+    flights_collection.find_one.side_effect = [
+        {"_id": existing_flight_id, "name": "Alpha Flight"},
+    ]
 
-    with pytest.raises(ValueError, match="already assigned to another flight"):
+    with pytest.raises(
+        ValueError,
+        match=r"already assigned to Alpha Flight\. Unassign them first\.",
+    ):
         assign_cadet_to_flight(cadet_id, new_flight_id)
 
     cadets_collection.update_one.assert_not_called()
@@ -132,10 +138,14 @@ def test_assign_cadet_to_flight_raises_if_commanding_different_flight(mock_get_c
     cadets_collection.find_one.return_value = {"_id": cadet_id}
     flights_collection.find_one.return_value = {
         "_id": commanded_flight_id,
+        "name": "Bravo Flight",
         "commander_cadet_id": cadet_id,
     }
 
-    with pytest.raises(ValueError, match="already commanding another flight"):
+    with pytest.raises(
+        ValueError,
+        match=r"already commanding Bravo Flight\. Remove them as commander first\.",
+    ):
         assign_cadet_to_flight(cadet_id, new_flight_id)
 
     cadets_collection.update_one.assert_not_called()
@@ -184,8 +194,16 @@ def test_create_flight_raises_if_commander_already_assigned_to_other_flight(
         "_id": commander_cadet_id,
         "flight_id": ObjectId(),
     }
+    cadets_existing_flight_id = cadets_collection.find_one.return_value["flight_id"]
+    flights_collection.find_one.return_value = {
+        "_id": cadets_existing_flight_id,
+        "name": "Alpha Flight",
+    }
 
-    with pytest.raises(ValueError, match="already assigned to another flight"):
+    with pytest.raises(
+        ValueError,
+        match=r"already assigned to Alpha Flight\. Unassign them first\.",
+    ):
         create_flight("Charlie Flight", commander_cadet_id)
 
     flights_collection.insert_one.assert_not_called()
@@ -207,10 +225,14 @@ def test_create_flight_raises_if_commander_already_commands_other_flight(
     cadets_collection.find_one.return_value = {"_id": commander_cadet_id}
     flights_collection.find_one.return_value = {
         "_id": ObjectId(),
+        "name": "Bravo Flight",
         "commander_cadet_id": commander_cadet_id,
     }
 
-    with pytest.raises(ValueError, match="already commanding another flight"):
+    with pytest.raises(
+        ValueError,
+        match=r"already commanding Bravo Flight\. Remove them as commander first\.",
+    ):
         create_flight("Charlie Flight", commander_cadet_id)
 
     flights_collection.insert_one.assert_not_called()
@@ -241,3 +263,35 @@ def test_unassign_all_cadets_from_flight_no_cadets(mock_get_collection):
     unassign_all_cadets_from_flight(flight_id)
 
     mock_collection.update_many.assert_called_once()
+
+
+@patch("services.cadets.db_assign_cadet_to_flight")
+@patch("services.cadets.get_cadet_by_id")
+def test_assign_cadet_to_flight_service_raises_if_already_in_same_flight(
+    mock_get_cadet_by_id, mock_db_assign_cadet_to_flight
+):
+    cadet_id = ObjectId()
+    flight_id = ObjectId()
+
+    mock_get_cadet_by_id.return_value = {"_id": cadet_id, "flight_id": flight_id}
+
+    with pytest.raises(ValueError, match="already in this flight"):
+        assign_cadet_to_flight_service(cadet_id, flight_id)
+
+    mock_db_assign_cadet_to_flight.assert_not_called()
+
+
+@patch("services.cadets.db_assign_cadet_to_flight")
+@patch("services.cadets.get_cadet_by_id")
+def test_assign_cadet_to_flight_service_calls_db_for_new_assignment(
+    mock_get_cadet_by_id, mock_db_assign_cadet_to_flight
+):
+    cadet_id = ObjectId()
+    current_flight_id = ObjectId()
+    new_flight_id = ObjectId()
+
+    mock_get_cadet_by_id.return_value = {"_id": cadet_id, "flight_id": current_flight_id}
+
+    assign_cadet_to_flight_service(cadet_id, new_flight_id)
+
+    mock_db_assign_cadet_to_flight.assert_called_once_with(cadet_id, new_flight_id)

--- a/tests/test_flight_management.py
+++ b/tests/test_flight_management.py
@@ -3,6 +3,7 @@ from bson import ObjectId
 import pytest
 
 from utils.db_schema_crud import (
+    create_flight,
     unassign_cadet_from_flight,
     assign_cadet_to_flight,
     unassign_all_cadets_from_flight,
@@ -52,52 +53,167 @@ def test_unassign_invalid_id(mock_get_collection):
 def test_assign_cadet_to_flight_raises_if_already_in_different_flight(
     mock_get_collection,
 ):
-    mock_collection = MagicMock()
-    mock_get_collection.return_value = mock_collection
+    cadets_collection = MagicMock()
+    flights_collection = MagicMock()
+    mock_get_collection.side_effect = lambda name: {
+        "cadets": cadets_collection,
+        "flights": flights_collection,
+    }[name]
 
     cadet_id = ObjectId()
     existing_flight_id = ObjectId()
     new_flight_id = ObjectId()
 
-    mock_collection.find_one.return_value = {
+    cadets_collection.find_one.return_value = {
         "_id": cadet_id,
         "flight_id": existing_flight_id,
     }
+    flights_collection.find_one.return_value = None
 
-    with pytest.raises(ValueError, match="already assigned"):
+    with pytest.raises(ValueError, match="already assigned to another flight"):
         assign_cadet_to_flight(cadet_id, new_flight_id)
 
-    mock_collection.update_one.assert_not_called()
+    cadets_collection.update_one.assert_not_called()
 
 
 @patch("utils.db_schema_crud.get_collection")
 def test_assign_cadet_to_flight_succeeds_when_unassigned(mock_get_collection):
-    mock_collection = MagicMock()
-    mock_get_collection.return_value = mock_collection
+    cadets_collection = MagicMock()
+    flights_collection = MagicMock()
+    mock_get_collection.side_effect = lambda name: {
+        "cadets": cadets_collection,
+        "flights": flights_collection,
+    }[name]
 
     cadet_id = ObjectId()
     flight_id = ObjectId()
 
-    mock_collection.find_one.return_value = {"_id": cadet_id}
+    cadets_collection.find_one.return_value = {"_id": cadet_id}
+    flights_collection.find_one.return_value = None
 
     assign_cadet_to_flight(cadet_id, flight_id)
 
-    mock_collection.update_one.assert_called_once()
+    cadets_collection.update_one.assert_called_once()
 
 
 @patch("utils.db_schema_crud.get_collection")
 def test_assign_cadet_to_same_flight_is_allowed(mock_get_collection):
-    mock_collection = MagicMock()
-    mock_get_collection.return_value = mock_collection
+    cadets_collection = MagicMock()
+    flights_collection = MagicMock()
+    mock_get_collection.side_effect = lambda name: {
+        "cadets": cadets_collection,
+        "flights": flights_collection,
+    }[name]
 
     cadet_id = ObjectId()
     flight_id = ObjectId()
 
-    mock_collection.find_one.return_value = {"_id": cadet_id, "flight_id": flight_id}
+    cadets_collection.find_one.return_value = {"_id": cadet_id, "flight_id": flight_id}
+    flights_collection.find_one.return_value = None
 
     assign_cadet_to_flight(cadet_id, flight_id)
 
-    mock_collection.update_one.assert_called_once()
+    cadets_collection.update_one.assert_called_once()
+
+
+@patch("utils.db_schema_crud.get_collection")
+def test_assign_cadet_to_flight_raises_if_commanding_different_flight(mock_get_collection):
+    cadets_collection = MagicMock()
+    flights_collection = MagicMock()
+    mock_get_collection.side_effect = lambda name: {
+        "cadets": cadets_collection,
+        "flights": flights_collection,
+    }[name]
+
+    cadet_id = ObjectId()
+    commanded_flight_id = ObjectId()
+    new_flight_id = ObjectId()
+
+    cadets_collection.find_one.return_value = {"_id": cadet_id}
+    flights_collection.find_one.return_value = {
+        "_id": commanded_flight_id,
+        "commander_cadet_id": cadet_id,
+    }
+
+    with pytest.raises(ValueError, match="already commanding another flight"):
+        assign_cadet_to_flight(cadet_id, new_flight_id)
+
+    cadets_collection.update_one.assert_not_called()
+
+
+@patch("utils.db_schema_crud.get_collection")
+def test_assign_cadet_to_same_flight_is_allowed_when_commanding_it(mock_get_collection):
+    cadets_collection = MagicMock()
+    flights_collection = MagicMock()
+    mock_get_collection.side_effect = lambda name: {
+        "cadets": cadets_collection,
+        "flights": flights_collection,
+    }[name]
+
+    cadet_id = ObjectId()
+    flight_id = ObjectId()
+
+    cadets_collection.find_one.return_value = {"_id": cadet_id}
+
+    def find_flight(query):
+        if query == {"commander_cadet_id": cadet_id, "_id": {"$ne": flight_id}}:
+            return None
+        return {"_id": flight_id, "commander_cadet_id": cadet_id}
+
+    flights_collection.find_one.side_effect = find_flight
+
+    assign_cadet_to_flight(cadet_id, flight_id)
+
+    cadets_collection.update_one.assert_called_once()
+
+
+@patch("utils.db_schema_crud.get_collection")
+def test_create_flight_raises_if_commander_already_assigned_to_other_flight(
+    mock_get_collection,
+):
+    cadets_collection = MagicMock()
+    flights_collection = MagicMock()
+    mock_get_collection.side_effect = lambda name: {
+        "cadets": cadets_collection,
+        "flights": flights_collection,
+    }[name]
+
+    commander_cadet_id = ObjectId()
+
+    cadets_collection.find_one.return_value = {
+        "_id": commander_cadet_id,
+        "flight_id": ObjectId(),
+    }
+
+    with pytest.raises(ValueError, match="already assigned to another flight"):
+        create_flight("Charlie Flight", commander_cadet_id)
+
+    flights_collection.insert_one.assert_not_called()
+
+
+@patch("utils.db_schema_crud.get_collection")
+def test_create_flight_raises_if_commander_already_commands_other_flight(
+    mock_get_collection,
+):
+    cadets_collection = MagicMock()
+    flights_collection = MagicMock()
+    mock_get_collection.side_effect = lambda name: {
+        "cadets": cadets_collection,
+        "flights": flights_collection,
+    }[name]
+
+    commander_cadet_id = ObjectId()
+
+    cadets_collection.find_one.return_value = {"_id": commander_cadet_id}
+    flights_collection.find_one.return_value = {
+        "_id": ObjectId(),
+        "commander_cadet_id": commander_cadet_id,
+    }
+
+    with pytest.raises(ValueError, match="already commanding another flight"):
+        create_flight("Charlie Flight", commander_cadet_id)
+
+    flights_collection.insert_one.assert_not_called()
 
 
 @patch("utils.db_schema_crud.get_collection")

--- a/utils/attendance_status.py
+++ b/utils/attendance_status.py
@@ -8,6 +8,8 @@ STATUS_LABELS = {
     "waived": "Excused",
 }
 
+NO_RECORD_STATUS_LABEL = "No Record"
+
 
 def get_effective_attendance_status(
     status: str | None,
@@ -34,6 +36,8 @@ def get_attendance_status_label(
 
 def get_attendance_status_cell_style(val: Any) -> str:
     status = str(val or "")
+    if status == NO_RECORD_STATUS_LABEL:
+        return "background-color: #D9DDE6; color: #1f2937; font-weight: 700;"
     if status == "Present":
         return "background-color: #7FE08A; color: #0b2e13; font-weight: 700;"
     if status == "Absent":

--- a/utils/attendance_status.py
+++ b/utils/attendance_status.py
@@ -1,3 +1,14 @@
+from typing import Any
+
+
+STATUS_LABELS = {
+    "present": "Present",
+    "absent": "Absent",
+    "excused": "Excused",
+    "waived": "Excused",
+}
+
+
 def get_effective_attendance_status(
     status: str | None,
     waiver_status: str | None = None,
@@ -9,3 +20,24 @@ def get_effective_attendance_status(
         return "waived"
 
     return normalized_status
+
+
+def get_attendance_status_label(
+    status: str | None,
+    waiver_status: str | None = None,
+    *,
+    default: str = "",
+) -> str:
+    effective_status = get_effective_attendance_status(status, waiver_status)
+    return STATUS_LABELS.get(effective_status, default)
+
+
+def get_attendance_status_cell_style(val: Any) -> str:
+    status = str(val or "")
+    if status == "Present":
+        return "background-color: #7FE08A; color: #0b2e13; font-weight: 700;"
+    if status == "Absent":
+        return "background-color: #E07F7F; color: #2b0b0b; font-weight: 700;"
+    if status == "Excused":
+        return "background-color: #E0D27F; color: #2b240b; font-weight: 700;"
+    return ""

--- a/utils/db_schema_crud.py
+++ b/utils/db_schema_crud.py
@@ -621,15 +621,23 @@ def _validate_flight_association(
         and cadet.get("flight_id")
         and cadet["flight_id"] != target_object_id
     ):
-        raise ValueError("Cadet is already assigned to another flight. Unassign them first.")
+        assigned_flight = flights_col.find_one({"_id": cadet["flight_id"]})
+        assigned_flight_name = (
+            assigned_flight.get("name") if assigned_flight else "another flight"
+        )
+        raise ValueError(
+            f"Cadet is already assigned to {assigned_flight_name}. Unassign them first."
+        )
 
     commander_query = {"commander_cadet_id": cadet_object_id}
     if target_object_id is not None:
         commander_query["_id"] = {"$ne": target_object_id}
 
-    if flights_col.find_one(commander_query):
+    commanded_flight = flights_col.find_one(commander_query)
+    if commanded_flight:
+        commanded_flight_name = commanded_flight.get("name", "another flight")
         raise ValueError(
-            "Cadet is already commanding another flight. Remove them as commander first."
+            f"Cadet is already commanding {commanded_flight_name}. Remove them as commander first."
         )
 
 

--- a/utils/db_schema_crud.py
+++ b/utils/db_schema_crud.py
@@ -603,10 +603,43 @@ def delete_waiver_approval(approval_id: str | ObjectId) -> DeleteResult | None:
 # -- Flights
 
 
+def _validate_flight_association(
+    cadet_id: str | ObjectId,
+    target_flight_id: str | ObjectId | None = None,
+) -> None:
+    cadets_col = get_collection("cadets")
+    flights_col = get_collection("flights")
+    if cadets_col is None or flights_col is None:
+        return
+
+    cadet_object_id = ObjectId(cadet_id)
+    target_object_id = ObjectId(target_flight_id) if target_flight_id is not None else None
+
+    cadet = cadets_col.find_one({"_id": cadet_object_id})
+    if (
+        cadet
+        and cadet.get("flight_id")
+        and cadet["flight_id"] != target_object_id
+    ):
+        raise ValueError("Cadet is already assigned to another flight. Unassign them first.")
+
+    commander_query = {"commander_cadet_id": cadet_object_id}
+    if target_object_id is not None:
+        commander_query["_id"] = {"$ne": target_object_id}
+
+    if flights_col.find_one(commander_query):
+        raise ValueError(
+            "Cadet is already commanding another flight. Remove them as commander first."
+        )
+
+
 def create_flight(name: str, commander_cadet_id: str | ObjectId):
     col = get_collection("flights")
     if col is None:
         return None
+
+    _validate_flight_association(commander_cadet_id)
+
     return col.insert_one(
         {
             "name": name,
@@ -640,6 +673,10 @@ def update_flight(flight_id: str | ObjectId, updates: dict):
     col = get_collection("flights")
     if col is None:
         return None
+
+    if "commander_cadet_id" in updates:
+        _validate_flight_association(updates["commander_cadet_id"], flight_id)
+
     return col.update_one({"_id": ObjectId(flight_id)}, {"$set": updates})
 
 
@@ -732,11 +769,7 @@ def assign_cadet_to_flight(cadet_id: str | ObjectId, flight_id: str | ObjectId):
     if col is None:
         return None
 
-    cadet = col.find_one({"_id": ObjectId(cadet_id)})
-    if cadet and cadet.get("flight_id") and cadet["flight_id"] != ObjectId(flight_id):
-        raise ValueError(
-            "Cadet is already assigned to another flight. Unassign them first."
-        )
+    _validate_flight_association(cadet_id, flight_id)
 
     return col.update_one(
         {"_id": ObjectId(cadet_id)},


### PR DESCRIPTION
This PR improves attendance workflows and admin reliability across the app by overhauling Modify Attendance to distinguish No Record from Present, avoid accidental mass updates, and treat unresolved cadets as absent after an event ends, while also making attendance status styling consistent with the dashboard. It also tightens flight management by enforcing flight exclusivity across flight commanders and members, preserving multiple expanded flight sections, and improving confirmation and error messaging, plus fixes event creation confirmation behavior so admin actions are clearer and more predictable overall.

closes #252
closes #253 
closes #254 
closes #255 