### PR TITLE
Separate events percentage, semester attendance report, configurable thresholds

### DIFF
--- a/pages/1_Dashboard.py
+++ b/pages/1_Dashboard.py
@@ -8,6 +8,7 @@ import streamlit as st
 
 from bson import ObjectId
 
+from services.dashboard import get_semester_df
 from services.events import closest_event_index
 from utils.auth import get_current_user, require_role
 from utils.attendance_status import (
@@ -17,7 +18,10 @@ from utils.attendance_status import (
 from utils.db import get_collection, get_db
 from utils.export import to_excel
 
-_MAX_ROWS = 2000
+
+require_role("admin", "cadre", "flight_commander")
+
+
 _MAX_EVENTS = 200
 
 
@@ -46,7 +50,7 @@ def _event_label(event_doc: dict[str, Any]) -> str:
     ev_type = str(event_doc.get("event_type", "") or "").upper()
     left = f"{ev_date} — {ev_name}".strip(" —")
     return f"{left} ({ev_type})".strip()
-require_role("admin", "cadre", "flight_commander")
+
 
 st.title("Dashboard")
 st.caption("Filter and review attendance records.")
@@ -97,8 +101,31 @@ if is_flight_commander_only and current_user:
                 flight_filter_id = flight_id
                 flight_filter_locked = True
 
-st.subheader("Filters")
+if roles & {"admin", "cadre"}:
+    st.subheader("Export Full Semester Data")
+    semester_df = get_semester_df()
 
+    if isinstance(semester_df, str):
+        st.warning(semester_df)
+
+    if isinstance(semester_df, pd.DataFrame):
+        col1, col2, spacer = st.columns([1.5, 2, 10])
+        col1.download_button(
+            "Export CSV",
+            semester_df.to_csv().encode("utf-8"),
+            "attendance.csv",
+            "text/csv",
+            key="semester_data_csv",
+        )
+        col2.download_button(
+            "Export Excel",
+            to_excel(semester_df),
+            "attendance.xlsx",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            key="semester_data_excel",
+        )
+
+st.subheader("Filters")
 today = datetime.now(timezone.utc).date()
 default_start = today.replace(month=1, day=1)
 
@@ -367,5 +394,3 @@ else:
                         st.warning("Excused")
 
                     st.dataframe(styler, width="stretch", hide_index=True)
-
-            st.divider()

--- a/pages/6_Event_Management_CRUD.py
+++ b/pages/6_Event_Management_CRUD.py
@@ -1,6 +1,11 @@
 import streamlit as st
 from datetime import date
-from services.event_config import get_event_config, save_event_config
+from services.event_config import (
+    get_event_config,
+    save_event_config,
+    _DEFAULT_PT_THRESHOLD,
+    _DEFAULT_LLAB_THRESHOLD,
+)
 from services.events import get_all_events, create_event, delete_event
 from utils.auth import require_role, get_current_user
 
@@ -60,8 +65,26 @@ with st.expander("Event Schedule Configuration", expanded=False):
         key="cfg_llab_days",
     )
 
+    st.divider()
+
+    st.markdown("Configure PT and LLAB absence thresholds.")
+    pt_threshold = st.number_input(
+        "PT Absence Threshold",
+        min_value=1,
+        max_value=20,
+        value=config.get("pt_threshold", _DEFAULT_PT_THRESHOLD),
+        step=1,
+    )
+    llab_threshold = st.number_input(
+        "LLAB Absence Threshold",
+        min_value=1,
+        max_value=20,
+        value=config.get("llab_threshold", _DEFAULT_LLAB_THRESHOLD),
+        step=1,
+    )
+
     if st.button("Save Schedule Configuration"):
-        if save_event_config(pt_days, llab_days):
+        if save_event_config(pt_days, llab_days, pt_threshold, llab_threshold):
             st.success("Schedule configuration saved!")
             config = get_event_config() or {}  # refresh so create form picks it up
             st.rerun()

--- a/pages/6_Waiver_Review.py
+++ b/pages/6_Waiver_Review.py
@@ -39,13 +39,13 @@ approver_user = require(
 approver_id = approver_user["_id"]
 
 status_filter = st.selectbox(
-    "Status", ["all", "pending", "approved", "denied"], index=0
+    "Status", ["All", "Pending", "Approved", "Denied"], index=0
 )
 flight_filter = st.selectbox("Flight", get_flight_options(), index=0)
 cadet_search = st.text_input("Cadet search (name or email)", "").strip().lower()
 
 viewer_roles = list(current_user.get("roles") or [])
-waivers = get_waivers(status_filter, viewer_roles)
+waivers = get_waivers(status_filter.lower(), viewer_roles)
 
 if not waivers:
     st.info("No waivers found for the selected filters.")

--- a/pages/8_Cadet_Attendance.py
+++ b/pages/8_Cadet_Attendance.py
@@ -13,6 +13,7 @@ from services.cadet_attendance import (
     count_absences,
     filter_rows,
     get_cadet_flight_label,
+    get_attendance_rate,
 )
 from services.waivers import WAIVER_STATUS_BADGE
 from utils.at_risk_email import PT_ABSENCE_THRESHOLD, LLAB_ABSENCE_THRESHOLD
@@ -79,18 +80,15 @@ def show_risk_banner(cadet_id: str, email: str, pt_absences: int, llab_absences:
 def show_absence_summary(rows: list[dict]):
     pt_absences = count_absences(rows, "pt")
     llab_absences = count_absences(rows, "lab")
-    total_records = len(rows)
-    attended_count = sum(
-        1 for r in rows if r["status"] in ("present", "excused", "waived")
-    )
-    attendance_rate = (
-        round(attended_count / total_records * 100) if total_records else 0
-    )
 
-    col1, col2, col3, col4 = st.columns(4)
-    col1.metric("Attendance Rate", f"{attendance_rate}%")
-    col2.metric("Total Events", total_records)
+    attendance_rate_pt = get_attendance_rate(rows, "PT")
+    attendance_rate_llab = get_attendance_rate(rows, "LAB")
 
+    col1, col2, col3, col4, col5 = st.columns(5)
+
+    col1.metric("Total Events", len(rows))
+
+    col2.metric("PT Attendance Rate", f"{attendance_rate_pt}%")
     pt_remaining = PT_ABSENCE_THRESHOLD - pt_absences
     col3.metric(
         "PT Absences",
@@ -99,8 +97,9 @@ def show_absence_summary(rows: list[dict]):
         delta_color="normal" if pt_remaining > 0 else "inverse",
     )
 
+    col4.metric("LLAB Attendance Rate", f"{attendance_rate_llab}%")
     llab_remaining = LLAB_ABSENCE_THRESHOLD - llab_absences
-    col4.metric(
+    col5.metric(
         "LLAB Absences",
         f"{llab_absences} / {LLAB_ABSENCE_THRESHOLD}",
         delta=f"{llab_remaining} remaining" if llab_remaining > 0 else "At limit",

--- a/services/cadet_attendance.py
+++ b/services/cadet_attendance.py
@@ -122,3 +122,20 @@ def get_cadet_flight_label(cadet: dict, flights: list[dict]) -> str:
         if flight["_id"] == cadet["flight_id"]:
             return flight.get("name", "—")
     return "—"
+
+
+def get_attendance_rate(rows: list[dict], event_type: str) -> int:
+    attended_llab = sum(
+        1
+        for r in rows
+        if (
+            r["status"] in ("present", "excused", "waived")
+            and r["event_type"] == event_type
+        )
+    )
+    llab_records = sum(1 for r in rows if r["event_type"] == event_type)
+    attendance_rate_llab = (
+        round(attended_llab / llab_records * 100) if llab_records else 0
+    )
+
+    return attendance_rate_llab

--- a/services/cadets.py
+++ b/services/cadets.py
@@ -11,6 +11,7 @@ from utils.db_schema_crud import (
     get_cadet_by_id,
     get_user_by_email,
     get_user_by_id,
+    get_all_cadets,
 )
 from utils.names import format_full_name
 
@@ -26,13 +27,6 @@ CLASS_TO_RANK = {
     "AS800": "700/800/900 (super senior)",
     "AS900": "700/800/900 (super senior)",
 }
-
-
-def get_all_cadets() -> list[dict]:
-    col = get_collection("cadets")
-    if col is None:
-        return []
-    return list(col.find())
 
 
 def get_cadets_by_flight(flight_id) -> list[dict]:

--- a/services/dashboard.py
+++ b/services/dashboard.py
@@ -1,143 +1,120 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 import pandas as pd
 
-from utils.db import get_collection, get_db
+from utils.db_schema_crud import (
+    get_all_cadets,
+    get_attendance_by_events,
+    get_events_by_type,
+    get_users_by_ids,
+    get_waivers_by_attendance_records,
+)
 from utils.names import format_full_name
 
 
-def normalize_status(status: str | None) -> str:
-    """Normalize a raw attendance status string to P/A/E."""
-    if not status:
-        return "A"
-    s = status.strip().lower()
-    if s == "present":
-        return "P"
-    if s == "absent":
-        return "A"
-    if s in ("excused", "waived"):
-        return "E"
-    return "A"
+def get_semester_data() -> dict | None:
+    cadets = get_all_cadets()
+    if not cadets:
+        return None
 
+    user_ids = [c["user_id"] for c in cadets]
+    users = get_users_by_ids(user_ids)
 
-def event_sort_key(e: dict) -> Any:
-    sd = e.get("start_date")
-    return sd if isinstance(sd, datetime) else str(sd or "")
+    year = datetime.now(timezone.utc).year
+    start = datetime(year, 1, 1, tzinfo=timezone.utc)
+    end = datetime(year, 12, 31, 23, 59, 59, tzinfo=timezone.utc)
 
+    all_events = get_events_by_type("pt") + get_events_by_type("lab")
+    events = [
+        e
+        for e in all_events
+        if isinstance(e.get("start_date"), datetime) and start <= e["start_date"] <= end
+    ]
+    if not events:
+        return None
 
-def format_event_row_label(event: dict[str, Any]) -> str:
-    """Format an event document into a display label: 'YYYY-MM-DD — Event Name'."""
-    sd = event.get("start_date")
-    if isinstance(sd, datetime):
-        date_str = sd.strftime("%Y-%m-%d")
-    else:
-        date_str = str(sd)[:10] if sd else "Unknown date"
-    name = event.get("event_name") or event.get("name") or ""
-    return f"{date_str} — {name}" if name else date_str
+    records = get_attendance_by_events([e["_id"] for e in events])
 
+    waivers = [
+        w
+        for w in get_waivers_by_attendance_records([r["_id"] for r in records])
+        if w.get("status") == "approved"
+    ]
 
-def build_attendance_grid(
-    cadet_docs: list[dict],
-    user_docs: list[dict],
-    event_docs: list[dict],
-    record_docs: list[dict],
-) -> tuple[list[str], list[str], list[list[str]]]:
-    """Build the attendance grid data for the dashboard.
-
-    Returns:
-        (event_row_labels, cadet_name_columns, grid_rows)
-        where grid_rows[i][j] is the P/A/E status for event i and cadet j.
-    """
-    name_by_user_id = {u["_id"]: format_full_name(u, "Unknown") for u in user_docs}
-
-    cadet_name_by_id = {
-        c["_id"]: name_by_user_id.get(c.get("user_id"), "Unknown") for c in cadet_docs
+    return {
+        "cadets": cadets,
+        "users": users,
+        "events": events,
+        "records": records,
+        "waivers": waivers,
     }
 
-    cadet_pairs = sorted(cadet_name_by_id.items(), key=lambda x: x[1].lower())
-    cadet_ids_sorted = [cid for cid, _ in cadet_pairs]
-    cadet_names_sorted = [nm for _, nm in cadet_pairs]
 
-    event_docs_sorted = sorted(event_docs, key=event_sort_key, reverse=True)
-    event_ids_sorted = [e["_id"] for e in event_docs_sorted]
-    event_row_labels = [format_event_row_label(e) for e in event_docs_sorted]
-
-    status_by_pair: dict[tuple, str] = {}
-    for r in record_docs:
-        key = (r.get("event_id"), r.get("cadet_id"))
-        status_by_pair[key] = normalize_status(r.get("status"))
-
-    grid_rows: list[list[str]] = []
-    for ev_id in event_ids_sorted:
-        row = [status_by_pair.get((ev_id, cid), "A") for cid in cadet_ids_sorted]
-        grid_rows.append(row)
-
-    return event_row_labels, cadet_names_sorted, grid_rows
-
-
-def get_data() -> tuple[list[dict], list[dict], list[dict], list[dict]] | None:
-    db = get_db()
-    if db is None:
-        return None
-
-    users_col = get_collection("users")
-    cadets_col = get_collection("cadets")
-    events_col = get_collection("events")
-    attendance_col = get_collection("attendance_records")
-
-    if any(x is None for x in (users_col, cadets_col, events_col, attendance_col)):
-        return None
-
-    assert users_col is not None
-    assert cadets_col is not None
-    assert events_col is not None
-    assert attendance_col is not None
-
-    cadet_docs = list(cadets_col.find({}, {"_id": 1, "user_id": 1}))
-    if not cadet_docs:
-        cadet_docs = []
-
-    user_ids = [c["user_id"] for c in cadet_docs if "user_id" in c]
-    user_docs = list(
-        users_col.find(
-            {"_id": {"$in": user_ids}}, {"_id": 1, "first_name": 1, "last_name": 1}
-        )
-    )
-
-    event_docs = list(events_col.find({}, {"_id": 1, "start_date": 1, "event_name": 1}))
-    if not event_docs:
-        event_docs = []
-
-    event_ids = [e["_id"] for e in event_docs]
-    record_docs = list(
-        attendance_col.find(
-            {"event_id": {"$in": event_ids}},
-            {"_id": 0, "event_id": 1, "cadet_id": 1, "status": 1},
-        )
-    )
-    return cadet_docs, user_docs, event_docs, record_docs
-
-
-def get_df() -> pd.DataFrame | str:
-    data = get_data()
-
+def get_semester_df() -> pd.DataFrame | str:
+    data = get_semester_data()
     if data is None:
-        return "Database is unavailable."
-    cadet_docs, user_docs, event_docs, record_docs = data
+        return "No data found."
 
-    if cadet_docs == []:
-        return "No cadets found yet."
-    if event_docs == []:
-        return "No events found yet."
+    cadets = data["cadets"]
+    users = data["users"]
+    events = data["events"]
+    records = data["records"]
+    waivers = data["waivers"]
 
-    event_row_labels, cadet_names, grid_rows = build_attendance_grid(
-        cadet_docs, user_docs, event_docs, record_docs
+    name_by_user_id = {u["_id"]: format_full_name(u, "Unknown") for u in users}
+    name_by_cadet = {
+        c["_id"]: name_by_user_id.get(c["user_id"], "Unknown") for c in cadets
+    }
+
+    status_map: dict[tuple, str] = {
+        (r["event_id"], r["cadet_id"]): (r.get("status") or "absent").lower()
+        for r in records
+    }
+    pair_to_record: dict[tuple, Any] = {
+        (r["event_id"], r["cadet_id"]): r["_id"] for r in records
+    }
+    waived_record_ids = {w["attendance_record_id"] for w in waivers}
+
+    cadets_sorted = sorted(
+        cadets, key=lambda c: name_by_cadet.get(c["_id"], "").lower()
     )
 
-    df = pd.DataFrame(
-        grid_rows,
-        index=pd.Index(event_row_labels),
-        columns=pd.Index(cadet_names),
-    )
+    rows = []
+    for c in cadets_sorted:
+        cid = c["_id"]
+        row: dict[str, Any] = {"Cadet": name_by_cadet.get(cid, "Unknown")}
+        pt_absences = llab_absences = approved_waivers = 0
 
-    return df
+        for e in events:
+            eid = e["_id"]
+            sd = e.get("start_date")
+            col_label = f"{sd.strftime('%m/%d') if isinstance(sd, datetime) else ''} {e.get('event_type', '').upper()}".strip()
+
+            rid = pair_to_record.get((eid, cid))
+            if rid in waived_record_ids:
+                val = "Waived"
+            else:
+                raw = status_map.get((eid, cid), "absent")
+                val = {
+                    "present": "Present",
+                    "absent": "Absent",
+                    "excused": "Excused",
+                }.get(raw, "Absent")
+
+            row[col_label] = val
+
+            if val == "Absent":
+                if e.get("event_type") == "pt":
+                    pt_absences += 1
+                elif e.get("event_type") == "lab":
+                    llab_absences += 1
+
+            if rid in waived_record_ids:
+                approved_waivers += 1
+
+        row["PT Absences"] = pt_absences
+        row["LLAB Absences"] = llab_absences
+        row["Approved Waivers"] = approved_waivers
+        rows.append(row)
+
+    return pd.DataFrame(rows)

--- a/services/event_config.py
+++ b/services/event_config.py
@@ -2,13 +2,20 @@ from utils.db import get_db
 
 _DEFAULT_PT_DAYS = ["Monday", "Tuesday", "Thursday"]
 _DEFAULT_LLAB_DAYS = ["Friday"]
+_DEFAULT_PT_THRESHOLD = 9
+_DEFAULT_LLAB_THRESHOLD = 2
 
 
 def get_event_config() -> dict | None:
     """Return the event schedule config, creating a default one if it doesn't exist."""
     db = get_db()
     if db is None:
-        return {"pt_days": _DEFAULT_PT_DAYS, "llab_days": _DEFAULT_LLAB_DAYS}
+        return {
+            "pt_days": _DEFAULT_PT_DAYS,
+            "llab_days": _DEFAULT_LLAB_DAYS,
+            "pt_threshold": _DEFAULT_PT_THRESHOLD,
+            "llab_threshold": _DEFAULT_LLAB_THRESHOLD,
+        }
 
     config = db.event_config.find_one({})
     if not config:
@@ -16,20 +23,49 @@ def get_event_config() -> dict | None:
             {
                 "pt_days": _DEFAULT_PT_DAYS,
                 "llab_days": _DEFAULT_LLAB_DAYS,
+                "pt_threshold": _DEFAULT_PT_THRESHOLD,
+                "llab_threshold": _DEFAULT_LLAB_THRESHOLD,
             }
         )
         config = db.event_config.find_one({})
 
-    return config or {"pt_days": _DEFAULT_PT_DAYS, "llab_days": _DEFAULT_LLAB_DAYS}
+    return config or {
+        "pt_days": _DEFAULT_PT_DAYS,
+        "llab_days": _DEFAULT_LLAB_DAYS,
+        "pt_threshold": _DEFAULT_PT_THRESHOLD,
+        "llab_threshold": _DEFAULT_LLAB_THRESHOLD,
+    }
 
 
-def save_event_config(pt_days: list[str], llab_days: list[str]) -> bool:
-    """Persist updated PT/LLAB day selections. Returns True on success."""
+def save_event_config(
+    pt_days: list[str],
+    llab_days: list[str],
+    pt_threshold: int,
+    llab_threshold: int,
+) -> bool:
+    """Persist updated PT/LLAB day and threshold selections. Returns True on success."""
     db = get_db()
     if db is None:
         return False
     db.event_config.update_one(
         {},
-        {"$set": {"pt_days": pt_days, "llab_days": llab_days}},
+        {
+            "$set": {
+                "pt_days": pt_days,
+                "llab_days": llab_days,
+                "pt_threshold": pt_threshold,
+                "llab_threshold": llab_threshold,
+            }
+        },
     )
     return True
+
+
+def get_absence_thresholds() -> tuple[int, int]:
+    config = get_event_config()
+    if config is None:
+        return (9, 2)
+    return (
+        config.get("pt_absence_threshold", 9),
+        config.get("llab_absence_threshold", 2),
+    )

--- a/services/flight_management.py
+++ b/services/flight_management.py
@@ -238,7 +238,7 @@ def get_member_selection_table(
     table.insert(
         0,
         "Unassign",
-        [cadet_id in selected_set for cadet_id in member_cadet_ids],
+        [cadet_id in selected_set for cadet_id in member_cadet_ids],  # type: ignore
     )
     return table
 
@@ -280,7 +280,7 @@ def _build_cadet_table(
     if not include_selection:
         column_order = ["Cadet", "Rank", "Email", "Current Flight"]
 
-    return pd.DataFrame(table_rows, columns=column_order)
+    return pd.DataFrame(table_rows, columns=list(column_order))  # type: ignore
 
 
 def _build_member_table(
@@ -301,7 +301,7 @@ def _build_member_table(
 
     return pd.DataFrame(
         table_rows,
-        columns=["Cadet", "Role", "Rank", "Email", "Current Flight"],
+        columns=["Cadet", "Role", "Rank", "Email", "Current Flight"],  # type: ignore
     )
 
 

--- a/utils/at_risk_email.py
+++ b/utils/at_risk_email.py
@@ -18,13 +18,13 @@ from utils.db_schema_crud import (
 )
 from utils.attendance_status import get_effective_attendance_status
 from utils.names import format_full_name
+from services.event_config import get_absence_thresholds
 
 
 SENDER_EMAIL = os.getenv("EMAIL_ADDRESS")
 SENDER_PASSWORD = os.getenv("EMAIL_APP_PASSWORD")
 
-PT_ABSENCE_THRESHOLD = 9
-LLAB_ABSENCE_THRESHOLD = 2
+PT_ABSENCE_THRESHOLD, LLAB_ABSENCE_THRESHOLD = get_absence_thresholds()
 
 
 def get_at_risk_cadets() -> list[dict]:

--- a/utils/db_schema_crud.py
+++ b/utils/db_schema_crud.py
@@ -52,6 +52,14 @@ def get_users_by_role(role: str) -> list[dict]:
     return list(col.find({"roles": role}))
 
 
+def get_users_by_ids(user_ids: list[str | ObjectId]) -> list[dict]:
+    col = get_collection("users")
+    if col is None:
+        return []
+    object_ids = [ObjectId(u_id) for u_id in user_ids]
+    return list(col.find({"_id": {"$in": object_ids}}))
+
+
 def update_user(user_id: str | ObjectId, updates: dict) -> UpdateResult | None:
     col = get_collection("users")
     if col is None:
@@ -325,6 +333,14 @@ def get_attendance_by_event(event_id: str | ObjectId) -> list[dict]:
     if col is None:
         return []
     return list(col.find({"event_id": ObjectId(event_id)}))
+
+
+def get_attendance_by_events(events_ids: list[str | ObjectId]) -> list[dict]:
+    col = get_collection("attendance_records")
+    if col is None:
+        return []
+    object_ids = [ObjectId(e_id) for e_id in events_ids]
+    return list(col.find({"event_id": {"$in": object_ids}}))
 
 
 def get_attendance_by_cadet(cadet_id: str | ObjectId) -> list[dict]:
@@ -613,14 +629,12 @@ def _validate_flight_association(
         return
 
     cadet_object_id = ObjectId(cadet_id)
-    target_object_id = ObjectId(target_flight_id) if target_flight_id is not None else None
+    target_object_id = (
+        ObjectId(target_flight_id) if target_flight_id is not None else None
+    )
 
     cadet = cadets_col.find_one({"_id": cadet_object_id})
-    if (
-        cadet
-        and cadet.get("flight_id")
-        and cadet["flight_id"] != target_object_id
-    ):
+    if cadet and cadet.get("flight_id") and cadet["flight_id"] != target_object_id:
         assigned_flight = flights_col.find_one({"_id": cadet["flight_id"]})
         assigned_flight_name = (
             assigned_flight.get("name") if assigned_flight else "another flight"


### PR DESCRIPTION
i lost the meaning of the word threshold somewhere along the way, might have misspelled it

- separate percentages for PT and LLAB (closes #239)
- added pt and llab thresholds to event config (closes #205)
- added export buttons for semester export (closes #211)

minor fixes:
- in Waivers review page: change filters to start with a capital letter
- deleted empty seed_demo_admin.py
- removed duplicate get_all_cadets() from services/cadets.py

unfortunately, did not create any merge conflicts :(
