### PR TITLE
Closes #30, #221, #233 email toggle, configurable check-in window, email regex

### DIFF
--- a/pages/11_Event_Code_Admin.py
+++ b/pages/11_Event_Code_Admin.py
@@ -5,7 +5,6 @@ from zoneinfo import ZoneInfo, available_timezones
 
 import streamlit as st
 
-from services.attendance import CHECKIN_WINDOW_MINUTES
 from services.event_code_display import (
     build_code_panel_html,
     build_fullscreen_code_html,
@@ -18,6 +17,7 @@ from services.event_codes import (
     is_expiry_valid,
     latest_allowed_expiry,
 )
+from services.event_config import get_checkin_window_minutes
 from services.events import closest_event_index, get_all_events
 from utils.auth import get_current_user, require_role
 from utils.db_schema_crud import get_user_by_email
@@ -81,7 +81,7 @@ if max_expires_at is not None:
     local_event_start = max_expires_at.astimezone(ZoneInfo(tz_name))
     st.caption(
         "Codes must expire no later than the event start time "
-        f"({CHECKIN_WINDOW_MINUTES}-minute check-in window)."
+        f"({get_checkin_window_minutes()}-minute check-in window)."
     )
     st.caption(
         f"Selected event starts at {local_event_start.strftime('%Y-%m-%d %I:%M %p %Z')}"

--- a/pages/6_Event_Management_CRUD.py
+++ b/pages/6_Event_Management_CRUD.py
@@ -5,6 +5,8 @@ from services.event_config import (
     save_event_config,
     _DEFAULT_PT_THRESHOLD,
     _DEFAULT_LLAB_THRESHOLD,
+    _DEFAULT_CHECKIN_WINDOW_MINUTES,
+    _DEFAULT_EMAILS_ENABLED,
 )
 from services.events import get_all_events, create_event, delete_event
 from utils.auth import require_role, get_current_user
@@ -83,8 +85,28 @@ with st.expander("Event Schedule Configuration", expanded=False):
         step=1,
     )
 
+    st.divider()
+
+    st.markdown("Configure check-in window and email notifications.")
+    checkin_window_minutes = st.number_input(
+        "Check-in Window (minutes)",
+        min_value=1,
+        max_value=60,
+        value=config.get("checkin_window_minutes", _DEFAULT_CHECKIN_WINDOW_MINUTES),
+        step=1,
+        help="How many minutes before event start cadets can check in.",
+    )
+    emails_enabled = st.checkbox(
+        "Enable email notifications",
+        value=config.get("emails_enabled", _DEFAULT_EMAILS_ENABLED),
+        help="When unchecked, no at-risk or waiver emails will be sent.",
+    )
+
     if st.button("Save Schedule Configuration"):
-        if save_event_config(pt_days, llab_days, pt_threshold, llab_threshold):
+        if save_event_config(
+            pt_days, llab_days, pt_threshold, llab_threshold,
+            checkin_window_minutes, emails_enabled
+        ):
             st.success("Schedule configuration saved!")
             config = get_event_config() or {}  # refresh so create form picks it up
             st.rerun()

--- a/services/admin_users.py
+++ b/services/admin_users.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import re
 from typing import Any, Dict, List, Tuple
+
+_EMAIL_RE = re.compile(r"^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$")
 
 
 def summarize_user(user: Dict[str, Any]) -> Dict[str, Any]:
@@ -85,7 +88,7 @@ def validate_new_user_data(
     raw_email = (email or "").strip()
     if not raw_email:
         errors["email"] = "Email is required."
-    elif "@" not in raw_email or "." not in raw_email.split("@", 1)[-1]:
+    elif not _EMAIL_RE.fullmatch(raw_email):
         errors["email"] = "Email looks invalid."
     elif raw_email.lower() in {e.lower() for e in existing_emails}:
         errors["email"] = "A user with this email already exists."
@@ -148,7 +151,7 @@ def build_update_user_payload(
 
     if not raw_email:
         errors["email"] = "Email is required."
-    elif "@" not in raw_email or "." not in raw_email.split("@", 1)[-1]:
+    elif not _EMAIL_RE.fullmatch(raw_email):
         errors["email"] = "Email looks invalid."
     elif raw_email.lower() in {e.lower() for e in other_emails}:
         errors["email"] = "A user with this email already exists."

--- a/services/attendance.py
+++ b/services/attendance.py
@@ -2,8 +2,9 @@ import secrets
 from typing import Any
 from datetime import datetime, timedelta, timezone
 
+from services.event_config import get_checkin_window_minutes
 
-CHECKIN_WINDOW_MINUTES = 10
+CHECKIN_WINDOW_MINUTES = 10  # fallback used by tests and legacy imports
 
 
 def generate_attendance_password() -> str:
@@ -29,7 +30,12 @@ def _ensure_utc(dt: datetime) -> datetime:
     return dt
 
 
-def is_within_checkin_window(event: dict[str, Any], now: datetime) -> bool:
+def is_within_checkin_window(
+    event: dict[str, Any],
+    now: datetime,
+    *,
+    window_minutes: int | None = None,
+) -> bool:
     start = event.get("start_date")
     if not isinstance(start, datetime):
         return False
@@ -37,5 +43,6 @@ def is_within_checkin_window(event: dict[str, Any], now: datetime) -> bool:
     start = _ensure_utc(start)
     now = _ensure_utc(now)
 
-    checkin_open = start - timedelta(minutes=CHECKIN_WINDOW_MINUTES)
+    minutes = window_minutes if window_minutes is not None else get_checkin_window_minutes()
+    checkin_open = start - timedelta(minutes=minutes)
     return checkin_open <= now <= start

--- a/services/event_config.py
+++ b/services/event_config.py
@@ -4,37 +4,33 @@ _DEFAULT_PT_DAYS = ["Monday", "Tuesday", "Thursday"]
 _DEFAULT_LLAB_DAYS = ["Friday"]
 _DEFAULT_PT_THRESHOLD = 9
 _DEFAULT_LLAB_THRESHOLD = 2
+_DEFAULT_CHECKIN_WINDOW_MINUTES = 10
+_DEFAULT_EMAILS_ENABLED = True
+
+
+def _defaults() -> dict:
+    return {
+        "pt_days": _DEFAULT_PT_DAYS,
+        "llab_days": _DEFAULT_LLAB_DAYS,
+        "pt_threshold": _DEFAULT_PT_THRESHOLD,
+        "llab_threshold": _DEFAULT_LLAB_THRESHOLD,
+        "checkin_window_minutes": _DEFAULT_CHECKIN_WINDOW_MINUTES,
+        "emails_enabled": _DEFAULT_EMAILS_ENABLED,
+    }
 
 
 def get_event_config() -> dict | None:
     """Return the event schedule config, creating a default one if it doesn't exist."""
     db = get_db()
     if db is None:
-        return {
-            "pt_days": _DEFAULT_PT_DAYS,
-            "llab_days": _DEFAULT_LLAB_DAYS,
-            "pt_threshold": _DEFAULT_PT_THRESHOLD,
-            "llab_threshold": _DEFAULT_LLAB_THRESHOLD,
-        }
+        return _defaults()
 
     config = db.event_config.find_one({})
     if not config:
-        db.event_config.insert_one(
-            {
-                "pt_days": _DEFAULT_PT_DAYS,
-                "llab_days": _DEFAULT_LLAB_DAYS,
-                "pt_threshold": _DEFAULT_PT_THRESHOLD,
-                "llab_threshold": _DEFAULT_LLAB_THRESHOLD,
-            }
-        )
+        db.event_config.insert_one(_defaults())
         config = db.event_config.find_one({})
 
-    return config or {
-        "pt_days": _DEFAULT_PT_DAYS,
-        "llab_days": _DEFAULT_LLAB_DAYS,
-        "pt_threshold": _DEFAULT_PT_THRESHOLD,
-        "llab_threshold": _DEFAULT_LLAB_THRESHOLD,
-    }
+    return config or _defaults()
 
 
 def save_event_config(
@@ -42,8 +38,10 @@ def save_event_config(
     llab_days: list[str],
     pt_threshold: int,
     llab_threshold: int,
+    checkin_window_minutes: int = _DEFAULT_CHECKIN_WINDOW_MINUTES,
+    emails_enabled: bool = _DEFAULT_EMAILS_ENABLED,
 ) -> bool:
-    """Persist updated PT/LLAB day and threshold selections. Returns True on success."""
+    """Persist updated schedule configuration. Returns True on success."""
     db = get_db()
     if db is None:
         return False
@@ -55,6 +53,8 @@ def save_event_config(
                 "llab_days": llab_days,
                 "pt_threshold": pt_threshold,
                 "llab_threshold": llab_threshold,
+                "checkin_window_minutes": checkin_window_minutes,
+                "emails_enabled": emails_enabled,
             }
         },
     )
@@ -69,3 +69,17 @@ def get_absence_thresholds() -> tuple[int, int]:
         config.get("pt_absence_threshold", 9),
         config.get("llab_absence_threshold", 2),
     )
+
+
+def get_checkin_window_minutes() -> int:
+    config = get_event_config()
+    if config is None:
+        return _DEFAULT_CHECKIN_WINDOW_MINUTES
+    return int(config.get("checkin_window_minutes", _DEFAULT_CHECKIN_WINDOW_MINUTES))
+
+
+def get_emails_enabled() -> bool:
+    config = get_event_config()
+    if config is None:
+        return _DEFAULT_EMAILS_ENABLED
+    return bool(config.get("emails_enabled", _DEFAULT_EMAILS_ENABLED))

--- a/tests/test_attendance_checkin.py
+++ b/tests/test_attendance_checkin.py
@@ -55,41 +55,44 @@ def test_returns_false_when_same_cadet_checked_into_different_event_only():
 # ------------------ test is_within_checkin_window -------------------------
 
 
+W = {"window_minutes": 10}
+
+
 def test_returns_true_within_window():
     event = create_event(5)
-    assert is_within_checkin_window(event, datetime.now(timezone.utc)) is True
+    assert is_within_checkin_window(event, datetime.now(timezone.utc), **W) is True
 
 
 def test_returns_true_at_window_open():
     event = create_event(10)
-    assert is_within_checkin_window(event, datetime.now(timezone.utc)) is True
+    assert is_within_checkin_window(event, datetime.now(timezone.utc), **W) is True
 
 
 def test_returns_true_at_event_start():
     now = datetime.now(timezone.utc)
     event = create_event(0)
-    assert is_within_checkin_window(event, now) is True
+    assert is_within_checkin_window(event, now, **W) is True
 
 
 def test_returns_false_before_window():
     event = create_event(20)
-    assert is_within_checkin_window(event, datetime.now(timezone.utc)) is False
+    assert is_within_checkin_window(event, datetime.now(timezone.utc), **W) is False
 
 
 def test_returns_false_after_event_starts():
     event = create_event(-5)
-    assert is_within_checkin_window(event, datetime.now(timezone.utc)) is False
+    assert is_within_checkin_window(event, datetime.now(timezone.utc), **W) is False
 
 
 def test_returns_false_missing_start_date():
-    assert is_within_checkin_window({}, datetime.now(timezone.utc)) is False
+    assert is_within_checkin_window({}, datetime.now(timezone.utc), **W) is False
 
 
 def test_returns_false_if_start_date_is_not_datetime():
     event = {"start_date": "2026-01-01"}
-    assert is_within_checkin_window(event, datetime.now(timezone.utc)) is False
+    assert is_within_checkin_window(event, datetime.now(timezone.utc), **W) is False
 
 
 def test_no_timezone_info():
     event = {"start_date": datetime.now(timezone.utc) + timedelta(minutes=5)}
-    assert is_within_checkin_window(event, datetime.now(timezone.utc)) is True
+    assert is_within_checkin_window(event, datetime.now(timezone.utc), **W) is True

--- a/utils/at_risk_email.py
+++ b/utils/at_risk_email.py
@@ -18,7 +18,7 @@ from utils.db_schema_crud import (
 )
 from utils.attendance_status import get_effective_attendance_status
 from utils.names import format_full_name
-from services.event_config import get_absence_thresholds
+from services.event_config import get_absence_thresholds, get_emails_enabled
 
 
 SENDER_EMAIL = os.getenv("EMAIL_ADDRESS")
@@ -226,6 +226,8 @@ def send_to_student(
     pt_absences: int,
     llab_absences: int,
 ) -> bool:
+    if not get_emails_enabled():
+        return False
     if not SENDER_EMAIL or not SENDER_PASSWORD:
         return False
 
@@ -281,6 +283,8 @@ def send_to_flight_commander(at_risk: list[dict], sent, failed) -> tuple[int, in
 
 
 def send_at_risk_emails() -> tuple[int, int]:
+    if not get_emails_enabled():
+        return 0, 0
     at_risk = get_at_risk_cadets()
     if not at_risk:
         return 0, 0

--- a/utils/waiver_email.py
+++ b/utils/waiver_email.py
@@ -4,6 +4,7 @@ import smtplib
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 
+from services.event_config import get_emails_enabled
 from utils.db_schema_crud import update_waiver, get_waiver_by_id
 
 
@@ -44,6 +45,8 @@ def send_waiver_decision_email(
     status: str,
     comments: str = "",
 ) -> bool:
+    if not get_emails_enabled():
+        return False
     if not SENDER_EMAIL or not SENDER_PASSWORD:
         return False
 


### PR DESCRIPTION
## Summary

- **#30 Email toggle switch**: Added `emails_enabled` boolean to the `event_config` collection (default `true`). Both `send_at_risk_emails` / `send_to_student` and `send_waiver_decision_email` short-circuit when disabled. The toggle is exposed as a checkbox in the Event Management → Schedule Configuration expander.
- **#221 Configurable check-in window**: `CHECKIN_WINDOW_MINUTES` is no longer a hardcoded constant. The value lives in `event_config` (default 10 min) and is read at call time by `is_within_checkin_window`. The Event Code Admin page caption now shows the live configured value. `is_within_checkin_window` accepts an optional `window_minutes` kwarg so unit tests stay DB-free.
- **#233 Email format validation**: Replaced the weak `"@" in email and "." in domain` heuristic in `admin_users.validate_new_user_data` and `build_update_user_payload` with the same `re.fullmatch` regex already used by the cadet validator.

## Test plan

- [ ] All 81 non-DB-dependent unit tests pass (`pytest` excluding `test_at_risk_cadets` / `test_at_risk_email`)
- [ ] Disable email toggle in Event Management settings → confirm no emails fire when waiver is approved or at-risk run is triggered
- [ ] Change check-in window to 5 min → confirm cadets can only check in within the new window; Event Code Admin caption reflects the new value
- [ ] Create a user with an invalid email (e.g. `foo@bar`, `notanemail`) → confirm validation error in both create and edit forms

🤖 Generated with [Claude Code](https://claude.com/claude-code)