### PR TITLE
attendance modification audit history

### DIFF
--- a/pages/10_Commander_Attendance.py
+++ b/pages/10_Commander_Attendance.py
@@ -6,7 +6,16 @@ from typing import Any
 import pandas as pd
 import streamlit as st
 
-from services.commander_attendance import build_commander_roster, compute_upserts
+from services.attendance_modifications import (
+    apply_bulk_attendance_changes,
+    build_recent_changes_table,
+    get_event_change_history,
+    get_selected_change_id,
+    get_selected_change_item,
+    redo_change,
+    undo_change,
+)
+from services.commander_attendance import build_commander_roster, hydrate_cadet_names
 from services.events import closest_event_index, get_all_events, has_event_ended
 from utils.auth import get_current_user, require_role
 from utils.attendance_status import (
@@ -18,22 +27,97 @@ from utils.db_schema_crud import (
     get_all_cadets,
     get_attendance_by_event,
     get_user_by_email,
-    get_user_by_id,
-    upsert_attendance_record,
+    get_users_by_ids,
 )
 
 STATUS_OPTIONS = [NO_RECORD_STATUS_LABEL, "Present", "Absent", "Excused"]
 STATUS_TO_DB = {"Present": "present", "Absent": "absent", "Excused": "excused"}
+HISTORY_PAGE_SIZE = 10
 
 require_role("admin", "cadre")
 st.title("Modify Attendance")
 st.caption("Manually set attendance for cadets. These entries override self-check-ins.")
 
-if "_success_msg" not in st.session_state:
-    st.session_state["_success_msg"] = None
-if st.session_state["_success_msg"]:
-    st.success(st.session_state["_success_msg"])
-    st.session_state["_success_msg"] = None
+
+def _set_feedback(kind: str, message: str) -> None:
+    st.session_state["_attendance_feedback"] = {"kind": kind, "message": message}
+
+
+def _show_feedback() -> None:
+    feedback = st.session_state.pop("_attendance_feedback", None)
+    if not feedback:
+        return
+
+    kind = str(feedback.get("kind", "info") or "info")
+    message = str(feedback.get("message", "") or "").strip()
+    if not message:
+        return
+
+    if kind == "success":
+        st.success(message)
+    elif kind == "error":
+        st.error(message)
+    else:
+        st.info(message)
+
+
+def _sync_history_state(event_id: str) -> None:
+    previous_event_id = st.session_state.get("_attendance_history_event_id")
+    if previous_event_id == event_id:
+        return
+
+    st.session_state["_attendance_history_event_id"] = event_id
+    st.session_state["_attendance_history_page"] = 1
+    st.session_state["_attendance_selected_change_id"] = None
+    st.session_state["_attendance_recent_changes_table_version"] = 0
+    st.session_state["_attendance_recent_changes_feedback"] = None
+
+
+def _recent_changes_table_key() -> str:
+    version = int(
+        st.session_state.get("_attendance_recent_changes_table_version", 0) or 0
+    )
+    return f"attendance_recent_changes_table_{version}"
+
+
+def _reset_recent_changes_selection() -> None:
+    st.session_state["_attendance_selected_change_id"] = None
+    st.session_state["_attendance_recent_changes_table_version"] = (
+        int(st.session_state.get("_attendance_recent_changes_table_version", 0) or 0)
+        + 1
+    )
+
+
+def _set_recent_changes_feedback(kind: str, message: str) -> None:
+    st.session_state["_attendance_recent_changes_feedback"] = {
+        "kind": kind,
+        "message": message,
+    }
+
+
+def _clear_recent_changes_feedback() -> None:
+    st.session_state["_attendance_recent_changes_feedback"] = None
+
+
+def _show_recent_changes_feedback() -> None:
+    feedback = st.session_state.get("_attendance_recent_changes_feedback")
+    if not feedback:
+        return
+
+    kind = str(feedback.get("kind", "info") or "info")
+    message = str(feedback.get("message", "") or "").strip()
+    if not message:
+        return
+
+    if kind == "success":
+        st.success(message)
+    elif kind == "error":
+        st.error(message)
+    else:
+        st.info(message)
+
+
+_show_feedback()
 
 current_user = get_current_user()
 assert current_user is not None
@@ -75,33 +159,16 @@ if selected_event is None:
 event_id: str = selected_event["_id"]
 event_has_ended = has_event_ended(selected_event)
 default_status = "Absent" if event_has_ended else NO_RECORD_STATUS_LABEL
+_sync_history_state(str(event_id))
 
 all_cadets = get_all_cadets()
 if not all_cadets:
     st.info("No cadets found.")
     st.stop()
 
-for i, c in enumerate(all_cadets):
-    uid = c.get("user_id")
-    if uid is None:
-        continue
-
-    try:
-        user_doc = get_user_by_id(uid)
-    except Exception:
-        user_doc = None
-    if user_doc is None:
-        continue
-
-    user_first = str(user_doc.get("first_name", "") or "").strip()
-    user_last = str(user_doc.get("last_name", "") or "").strip()
-    if not user_first and not user_last:
-        continue
-
-    c = dict(c)
-    c["first_name"] = user_first or c.get("first_name", "")
-    c["last_name"] = user_last or c.get("last_name", "")
-    all_cadets[i] = c
+cadet_user_ids = [c.get("user_id") for c in all_cadets if c.get("user_id") is not None]
+user_by_id = {user["_id"]: user for user in get_users_by_ids(cadet_user_ids)}
+all_cadets = hydrate_cadet_names(all_cadets, user_by_id)
 
 records = get_attendance_by_event(event_id)
 roster = build_commander_roster(all_cadets, records)
@@ -115,7 +182,8 @@ initial_statuses = [
 df = pd.DataFrame(
     {
         "Cadet": [
-            f"{str(e['cadet'].get('last_name', '') or '').strip()}, "
+            str(e["cadet"].get("name", "") or "").strip()
+            or f"{str(e['cadet'].get('last_name', '') or '').strip()}, "
             f"{str(e['cadet'].get('first_name', '') or '').strip()}".strip(", ")
             or "Unknown"
             for e in roster
@@ -167,14 +235,161 @@ if st.button("Save All", type="primary"):
         if row["Set Status"] != initial_statuses[idx]
         and row["Set Status"] in STATUS_TO_DB
     }
-    upserts = compute_upserts(roster, new_statuses)
-    for op in upserts:
-        upsert_attendance_record(
-            event_id=event_id,
-            cadet_id=op["cadet_id"],
-            status=op["status"],
-            recorded_by_user_id=user["_id"],
-            recorded_by_roles=list(user.get("roles", [])),
+    save_result = apply_bulk_attendance_changes(
+        event_id=event_id,
+        roster=roster,
+        new_statuses=new_statuses,
+        recorded_by_user_id=user["_id"],
+        recorded_by_roles=list(user.get("roles", [])),
+    )
+    if save_result["changed_count"] == 0:
+        _set_feedback("info", "No attendance changes to save.")
+    else:
+        st.session_state["_attendance_history_page"] = 1
+        _reset_recent_changes_selection()
+        _clear_recent_changes_feedback()
+        _set_feedback(
+            "success",
+            f"Saved attendance for {save_result['changed_count']} cadet(s).",
         )
-    st.session_state["_success_msg"] = f"Saved attendance for {len(upserts)} cadet(s)."
     st.rerun()
+
+st.subheader("Recent Changes")
+
+
+@st.fragment
+def _render_recent_changes() -> None:
+    history_page = int(st.session_state.get("_attendance_history_page", 1) or 1)
+    history = get_event_change_history(
+        event_id,
+        page=history_page,
+        page_size=HISTORY_PAGE_SIZE,
+    )
+
+    if not history["items"]:
+        st.caption("No saved attendance changes yet for this event.")
+        return
+
+    with st.container(border=True):
+        st.caption("Most recent attendance edits for the selected event.")
+        selected_change_id = st.session_state.get("_attendance_selected_change_id")
+        selection = st.dataframe(
+            build_recent_changes_table(history["items"]),
+            hide_index=True,
+            width="stretch",
+            column_config={
+                "Timestamp": st.column_config.TextColumn(disabled=True),
+                "Cadet": st.column_config.TextColumn(disabled=True),
+                "From": st.column_config.TextColumn(disabled=True),
+                "To": st.column_config.TextColumn(disabled=True),
+                "Changed By": st.column_config.TextColumn(disabled=True),
+                "Action": st.column_config.TextColumn(disabled=True),
+                "Available": st.column_config.TextColumn(disabled=True),
+            },
+            key=_recent_changes_table_key(),
+            on_select="rerun",
+            selection_mode="single-row",
+        )
+
+        previous_selected_change_id = st.session_state.get("_attendance_selected_change_id")
+        st.session_state["_attendance_selected_change_id"] = get_selected_change_id(
+            selection,
+            history["items"],
+        )
+
+        selected_change_id = st.session_state.get("_attendance_selected_change_id")
+        if selected_change_id != previous_selected_change_id:
+            _clear_recent_changes_feedback()
+
+        selected_item = get_selected_change_item(
+            selected_change_id,
+            history["items"],
+        )
+
+        st.divider()
+        _show_recent_changes_feedback()
+
+        if selected_item is not None:
+            st.caption(
+                f"Selected change: {selected_item['cadet_name']} • "
+                f"{selected_item['from_status']} -> {selected_item['to_status']}"
+            )
+
+            if selected_item["can_undo"]:
+                st.warning(
+                    f"Undo this change for {selected_item['cadet_name']}? This will restore "
+                    f"{selected_item['undo_target_label']}."
+                )
+                if st.button(
+                    "Confirm Undo",
+                    key=f"confirm_undo_{selected_item['change_id']}",
+                    type="primary",
+                ):
+                    ok, message = undo_change(
+                        selected_item["change_id"],
+                        recorded_by_user_id=user["_id"],
+                        recorded_by_roles=list(user.get("roles", [])),
+                    )
+                    if ok:
+                        st.session_state["_attendance_history_page"] = 1
+                        _reset_recent_changes_selection()
+                    _set_recent_changes_feedback(
+                        "success" if ok else "error",
+                        message,
+                    )
+                    st.rerun()
+            elif selected_item["can_redo"]:
+                st.warning(
+                    f"Redo this change for {selected_item['cadet_name']}? This will restore "
+                    f"{selected_item['redo_target_label']}."
+                )
+                if st.button(
+                    "Confirm Redo",
+                    key=f"confirm_redo_{selected_item['change_id']}",
+                    type="primary",
+                ):
+                    ok, message = redo_change(
+                        selected_item["change_id"],
+                        recorded_by_user_id=user["_id"],
+                        recorded_by_roles=list(user.get("roles", [])),
+                    )
+                    if ok:
+                        st.session_state["_attendance_history_page"] = 1
+                        _reset_recent_changes_selection()
+                    _set_recent_changes_feedback(
+                        "success" if ok else "error",
+                        message,
+                    )
+                    st.rerun()
+            elif selected_item["action_block_reason"]:
+                st.caption(selected_item["action_block_reason"])
+
+        st.divider()
+        page_col, prev_col, next_col = st.columns([3, 1, 1])
+        page_col.caption(
+            f"Page {history['page']} of {history['total_pages']}"
+            f" • {history['total_count']} total change(s)"
+        )
+        if prev_col.button(
+            "Previous",
+            key="attendance_history_prev",
+            disabled=history["page"] <= 1,
+            width="stretch",
+        ):
+            st.session_state["_attendance_history_page"] = history["page"] - 1
+            _reset_recent_changes_selection()
+            _clear_recent_changes_feedback()
+            st.rerun(scope="fragment")
+        if next_col.button(
+            "Next",
+            key="attendance_history_next",
+            disabled=history["page"] >= history['total_pages'],
+            width="stretch",
+        ):
+            st.session_state["_attendance_history_page"] = history["page"] + 1
+            _reset_recent_changes_selection()
+            _clear_recent_changes_feedback()
+            st.rerun(scope="fragment")
+
+
+_render_recent_changes()

--- a/services/attendance_modifications.py
+++ b/services/attendance_modifications.py
@@ -1,0 +1,555 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from math import ceil
+from typing import Any
+from uuid import uuid4
+
+import pandas as pd
+from bson import ObjectId
+
+from services.commander_attendance import compute_upserts
+from utils.attendance_status import (
+    NO_RECORD_STATUS_LABEL,
+    get_attendance_status_cell_style,
+    get_attendance_status_label,
+)
+from utils.audit_log import log_attendance_modification
+from utils.db import get_collection
+from utils.db_schema_crud import (
+    delete_attendance_record,
+    get_attendance_record_by_event_cadet,
+    get_cadets_by_ids,
+    get_users_by_ids,
+    get_waiver_by_attendance_record,
+    upsert_attendance_record,
+)
+from utils.datetime_utils import ensure_utc
+from utils.names import format_full_name
+
+
+_AUDIT_SOURCE = "attendance_modification"
+_ACTION_LABELS = {
+    "applied": "Saved",
+    "undo": "Undo",
+    "redo": "Redo",
+}
+
+
+def _normalize_status(status: Any) -> str | None:
+    normalized = str(status or "").strip().lower()
+    return normalized or None
+
+
+def _status_label(status: str | None) -> str:
+    return get_attendance_status_label(status, default=NO_RECORD_STATUS_LABEL)
+
+
+def _safe_object_id(value: str | ObjectId) -> ObjectId | None:
+    try:
+        return ObjectId(value)
+    except Exception:
+        return None
+
+
+def _record_operation(
+    before_record: dict[str, Any] | None,
+    after_record: dict[str, Any] | None,
+) -> str:
+    if before_record is None and after_record is not None:
+        return "create"
+    if before_record is not None and after_record is None:
+        return "delete"
+    return "update"
+
+
+def _fmt_timestamp(value: Any) -> str:
+    if not isinstance(value, datetime):
+        return "Unknown"
+    return ensure_utc(value).strftime("%Y-%m-%d %H:%M UTC")
+
+
+def _audit_docs(query: dict[str, Any]) -> list[dict[str, Any]]:
+    col = get_collection("audit_log")
+    if col is None:
+        return []
+
+    cursor = col.find(query)
+    if hasattr(cursor, "sort"):
+        try:
+            return list(cursor.sort("created_at", -1))
+        except TypeError:
+            pass
+
+    docs = list(cursor)
+    docs.sort(
+        key=lambda doc: doc.get("created_at")
+        or datetime.min.replace(tzinfo=timezone.utc),
+        reverse=True,
+    )
+    return docs
+
+
+def _paged_audit_docs(
+    query: dict[str, Any],
+    *,
+    skip: int,
+    limit: int,
+) -> list[dict[str, Any]]:
+    col = get_collection("audit_log")
+    if col is None:
+        return []
+
+    cursor = col.find(query)
+    if hasattr(cursor, "sort"):
+        try:
+            cursor = cursor.sort("created_at", -1)
+            if skip > 0:
+                cursor = cursor.skip(skip)
+            if limit > 0:
+                cursor = cursor.limit(limit)
+            return list(cursor)
+        except TypeError:
+            pass
+
+    docs = _audit_docs(query)
+    return docs[skip : skip + limit]
+
+
+def _pair_history_docs(event_id: ObjectId, cadet_id: ObjectId) -> list[dict[str, Any]]:
+    return _audit_docs(
+        {
+            "source": _AUDIT_SOURCE,
+            "event_id": event_id,
+            "cadet_id": cadet_id,
+        }
+    )
+
+
+def _latest_pair_history_doc(event_id: ObjectId, cadet_id: ObjectId) -> dict[str, Any] | None:
+    docs = _paged_audit_docs(
+        {
+            "source": _AUDIT_SOURCE,
+            "event_id": event_id,
+            "cadet_id": cadet_id,
+        },
+        skip=0,
+        limit=1,
+    )
+    return docs[0] if docs else None
+
+
+def _latest_visible_event_change_docs(event_id: str | ObjectId) -> list[dict[str, Any]]:
+    docs = _audit_docs(
+        {
+            "source": _AUDIT_SOURCE,
+            "event_id": ObjectId(event_id),
+        }
+    )
+
+    visible_docs: list[dict[str, Any]] = []
+    seen_cadet_ids: set[ObjectId] = set()
+    for doc in docs:
+        cadet_id = doc.get("cadet_id")
+        if cadet_id is None or cadet_id in seen_cadet_ids:
+            continue
+        seen_cadet_ids.add(cadet_id)
+        visible_docs.append(doc)
+    return visible_docs
+
+
+def _hydrate_changes(docs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if not docs:
+        return []
+
+    cadet_ids = [doc.get("cadet_id") for doc in docs if doc.get("cadet_id") is not None]
+    actor_ids = [doc.get("user_id") for doc in docs if doc.get("user_id") is not None]
+
+    cadets = get_cadets_by_ids(cadet_ids)
+    cadet_by_id = {cadet["_id"]: cadet for cadet in cadets}
+
+    cadet_user_ids = [cadet.get("user_id") for cadet in cadets if cadet.get("user_id")]
+    users = get_users_by_ids(cadet_user_ids + actor_ids)
+    user_by_id = {user["_id"]: user for user in users}
+
+    rows: list[dict[str, Any]] = []
+    for doc in docs:
+        metadata = doc.get("metadata") or {}
+        cadet = cadet_by_id.get(doc.get("cadet_id"))
+        cadet_user = user_by_id.get(cadet.get("user_id")) if cadet else None
+        actor = user_by_id.get(doc.get("user_id"))
+
+        cadet_name = format_full_name(cadet_user)
+        if not cadet_name and cadet:
+            first = str(cadet.get("first_name", "") or "").strip()
+            last = str(cadet.get("last_name", "") or "").strip()
+            cadet_name = f"{first} {last}".strip()
+        if not cadet_name:
+            cadet_name = "Unknown cadet"
+
+        changed_by = format_full_name(actor, "Unknown user")
+        from_status = _status_label(_normalize_status(metadata.get("old_status")))
+        to_status = _status_label(_normalize_status(metadata.get("new_status")))
+        action_key = str(doc.get("outcome", "applied")).strip().lower()
+
+        rows.append(
+            {
+                "change_id": str(doc.get("_id", "")),
+                "cadet_name": cadet_name,
+                "changed_by": changed_by,
+                "from_status": from_status,
+                "to_status": to_status,
+                "action": _ACTION_LABELS.get(action_key, action_key.title() or "Saved"),
+                "timestamp": _fmt_timestamp(doc.get("created_at")),
+            }
+        )
+
+    return rows
+
+
+def _set_attendance_state(
+    *,
+    event_id: str | ObjectId,
+    cadet_id: str | ObjectId,
+    status: str | None,
+    recorded_by_user_id: str | ObjectId,
+    recorded_by_roles: list[str] | None,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    before_record = get_attendance_record_by_event_cadet(event_id, cadet_id)
+
+    if status is None:
+        if before_record is not None:
+            delete_attendance_record(before_record["_id"])
+        return before_record, None
+
+    upsert_attendance_record(
+        event_id=event_id,
+        cadet_id=cadet_id,
+        status=status,
+        recorded_by_user_id=recorded_by_user_id,
+        recorded_by_roles=recorded_by_roles,
+    )
+    after_record = get_attendance_record_by_event_cadet(event_id, cadet_id)
+    return before_record, after_record
+
+
+def apply_bulk_attendance_changes(
+    *,
+    event_id: str | ObjectId,
+    roster: list[dict[str, Any]],
+    new_statuses: dict[str, str],
+    recorded_by_user_id: str | ObjectId,
+    recorded_by_roles: list[str] | None,
+) -> dict[str, Any]:
+    upserts = compute_upserts(roster, new_statuses)
+    if not upserts:
+        return {"ok": True, "changed_count": 0, "batch_id": None}
+
+    entry_by_cadet = {str(entry["cadet"]["_id"]): entry for entry in roster}
+    batch_id = uuid4().hex
+
+    for op in upserts:
+        cadet_id = op["cadet_id"]
+        entry = entry_by_cadet[str(cadet_id)]
+        before_record = entry.get("record")
+        old_status = _normalize_status(entry.get("current_status"))
+        new_status = _normalize_status(op.get("status"))
+
+        _, after_record = _set_attendance_state(
+            event_id=event_id,
+            cadet_id=cadet_id,
+            status=new_status,
+            recorded_by_user_id=recorded_by_user_id,
+            recorded_by_roles=recorded_by_roles,
+        )
+
+        log_attendance_modification(
+            event_id=event_id,
+            cadet_id=cadet_id,
+            user_id=recorded_by_user_id,
+            outcome="applied",
+            old_status=old_status,
+            new_status=new_status,
+            metadata={
+                "batch_id": batch_id,
+                "record_operation": _record_operation(before_record, after_record),
+                "old_record_id": str(before_record.get("_id", "")) if before_record else None,
+                "new_record_id": str(after_record.get("_id", "")) if after_record else None,
+                "recorded_by_roles": list(recorded_by_roles or []),
+            },
+        )
+
+    return {"ok": True, "changed_count": len(upserts), "batch_id": batch_id}
+
+
+def get_event_change_history(
+    event_id: str | ObjectId,
+    *,
+    page: int = 1,
+    page_size: int = 10,
+) -> dict[str, Any]:
+    visible_docs = _latest_visible_event_change_docs(event_id)
+    total_count = len(visible_docs)
+    total_pages = max(1, ceil(total_count / page_size)) if page_size > 0 else 1
+    page = min(max(page, 1), total_pages)
+    start = (page - 1) * page_size
+
+    docs = visible_docs[start : start + page_size]
+    items = _hydrate_changes(docs)
+    for doc, item in zip(docs, items):
+        latest_doc = _latest_pair_history_doc(doc["event_id"], doc["cadet_id"])
+        if latest_doc is not None:
+            item.update(_selected_action_state(doc, latest_doc))
+
+    return {
+        "items": items,
+        "page": page,
+        "page_size": page_size,
+        "total_count": total_count,
+        "total_pages": total_pages,
+    }
+
+
+def _selected_action_state(
+    selected_doc: dict[str, Any],
+    latest_doc: dict[str, Any],
+) -> dict[str, Any]:
+    selected_metadata = selected_doc.get("metadata") or {}
+    latest_status = _normalize_status(selected_metadata.get("new_status"))
+    restore_status = _normalize_status(selected_metadata.get("old_status"))
+    current_record = get_attendance_record_by_event_cadet(
+        selected_doc["event_id"],
+        selected_doc["cadet_id"],
+    )
+    current_status = _normalize_status(current_record.get("status") if current_record else None)
+
+    state = {
+        "can_undo": False,
+        "can_redo": False,
+        "undo_target_label": _status_label(restore_status),
+        "redo_target_label": _status_label(_normalize_status(selected_metadata.get("old_status"))),
+        "action_block_reason": "",
+    }
+
+    if selected_doc.get("_id") != latest_doc.get("_id"):
+        state["action_block_reason"] = (
+            "Only the latest change for this cadet can be undone or redone."
+        )
+        return state
+
+    if current_status != latest_status:
+        state["action_block_reason"] = "Attendance changed after this audit entry was created."
+        return state
+
+    outcome = str(selected_doc.get("outcome", "")).strip().lower()
+    if outcome == "undo":
+        state["can_redo"] = True
+        state["redo_target_label"] = _status_label(
+            _normalize_status(selected_metadata.get("old_status"))
+        )
+        return state
+
+    if restore_status is None and current_record is not None:
+        waiver = get_waiver_by_attendance_record(current_record["_id"])
+        if waiver is not None:
+            state["action_block_reason"] = (
+                "This change cannot be undone to No Record because the attendance record "
+                "has a waiver attached."
+            )
+            return state
+
+    state["can_undo"] = True
+    return state
+
+
+def build_recent_changes_table(items: list[dict[str, Any]]):
+    df = pd.DataFrame(
+        [
+            {
+                "Timestamp": item["timestamp"],
+                "Cadet": item["cadet_name"],
+                "From": item["from_status"],
+                "To": item["to_status"],
+                "Changed By": item["changed_by"],
+                "Action": item["action"],
+                "Available": (
+                    "Undo"
+                    if item["can_undo"]
+                    else "Redo" if item["can_redo"] else "Unavailable"
+                ),
+            }
+            for item in items
+        ]
+    )
+
+    styler = df.style
+    if hasattr(styler, "map"):
+        styler = styler.map(get_attendance_status_cell_style, subset=["From", "To"])
+    else:
+        styler = styler.applymap(
+            get_attendance_status_cell_style,
+            subset=["From", "To"],
+        )
+    return styler
+
+
+def get_selected_change_id(selection: Any, items: list[dict[str, Any]]) -> str | None:
+    if not selection:
+        return None
+
+    rows: list[int]
+    if isinstance(selection, dict):
+        rows = list(selection.get("selection", {}).get("rows", []))
+    else:
+        selection_data = getattr(selection, "selection", None)
+        if selection_data is None:
+            return None
+        if isinstance(selection_data, dict):
+            rows = list(selection_data.get("rows", []))
+        else:
+            rows = list(getattr(selection_data, "rows", []) or [])
+
+    if not rows:
+        return None
+
+    selected_index = rows[0]
+    if 0 <= selected_index < len(items):
+        return items[selected_index]["change_id"]
+    return None
+
+
+def get_selected_change_item(
+    selected_change_id: str | None,
+    items: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    if selected_change_id is None:
+        return None
+    return next(
+        (item for item in items if item["change_id"] == selected_change_id),
+        None,
+    )
+
+
+def _apply_change_from_audit(
+    *,
+    change_doc: dict[str, Any],
+    recorded_by_user_id: str | ObjectId,
+    recorded_by_roles: list[str] | None,
+    outcome: str,
+    relation_field: str,
+) -> tuple[bool, str]:
+    history_docs = _pair_history_docs(change_doc["event_id"], change_doc["cadet_id"])
+    if not history_docs or history_docs[0].get("_id") != change_doc.get("_id"):
+        return False, "Only the latest change can be modified."
+
+    metadata = change_doc.get("metadata") or {}
+    current_record = get_attendance_record_by_event_cadet(
+        change_doc["event_id"],
+        change_doc["cadet_id"],
+    )
+    current_status = _normalize_status(current_record.get("status") if current_record else None)
+    expected_current_status = _normalize_status(metadata.get("new_status"))
+    target_status = _normalize_status(metadata.get("old_status"))
+
+    if current_status != expected_current_status:
+        return False, "Attendance changed after this audit entry was created."
+
+    if target_status is None and current_record is not None:
+        waiver = get_waiver_by_attendance_record(current_record["_id"])
+        if waiver is not None:
+            return (
+                False,
+                "This change cannot be undone to No Record because the attendance record has a waiver attached.",
+            )
+
+    before_record, after_record = _set_attendance_state(
+        event_id=change_doc["event_id"],
+        cadet_id=change_doc["cadet_id"],
+        status=target_status,
+        recorded_by_user_id=recorded_by_user_id,
+        recorded_by_roles=recorded_by_roles,
+    )
+
+    log_attendance_modification(
+        event_id=change_doc["event_id"],
+        cadet_id=change_doc["cadet_id"],
+        user_id=recorded_by_user_id,
+        outcome=outcome,
+        old_status=current_status,
+        new_status=target_status,
+        metadata={
+            relation_field: str(change_doc["_id"]),
+            "record_operation": _record_operation(before_record, after_record),
+            "old_record_id": str(before_record.get("_id", "")) if before_record else None,
+            "new_record_id": str(after_record.get("_id", "")) if after_record else None,
+            "recorded_by_roles": list(recorded_by_roles or []),
+        },
+    )
+
+    return True, "Attendance change updated."
+
+
+def undo_change(
+    change_id: str | ObjectId,
+    *,
+    recorded_by_user_id: str | ObjectId,
+    recorded_by_roles: list[str] | None,
+) -> tuple[bool, str]:
+    oid = _safe_object_id(change_id)
+    if oid is None:
+        return False, "Could not find that attendance change."
+
+    col = get_collection("audit_log")
+    if col is None:
+        return False, "Database unavailable. Could not undo attendance change."
+
+    change_doc = col.find_one({"_id": oid, "source": _AUDIT_SOURCE})
+    if change_doc is None:
+        return False, "Could not find that attendance change."
+
+    if str(change_doc.get("outcome", "")).strip().lower() == "undo":
+        return False, "This change has already been undone."
+
+    ok, message = _apply_change_from_audit(
+        change_doc=change_doc,
+        recorded_by_user_id=recorded_by_user_id,
+        recorded_by_roles=recorded_by_roles,
+        outcome="undo",
+        relation_field="reverts_audit_id",
+    )
+    if not ok:
+        return False, message
+    return True, "Attendance change undone."
+
+
+def redo_change(
+    change_id: str | ObjectId,
+    *,
+    recorded_by_user_id: str | ObjectId,
+    recorded_by_roles: list[str] | None,
+) -> tuple[bool, str]:
+    oid = _safe_object_id(change_id)
+    if oid is None:
+        return False, "Could not find that attendance change."
+
+    col = get_collection("audit_log")
+    if col is None:
+        return False, "Database unavailable. Could not redo attendance change."
+
+    change_doc = col.find_one({"_id": oid, "source": _AUDIT_SOURCE})
+    if change_doc is None:
+        return False, "Could not find that attendance change."
+
+    if str(change_doc.get("outcome", "")).strip().lower() != "undo":
+        return False, "Only the latest undo can be redone."
+
+    ok, message = _apply_change_from_audit(
+        change_doc=change_doc,
+        recorded_by_user_id=recorded_by_user_id,
+        recorded_by_roles=recorded_by_roles,
+        outcome="redo",
+        relation_field="redoes_audit_id",
+    )
+    if not ok:
+        return False, message
+    return True, "Attendance change redone."

--- a/services/commander_attendance.py
+++ b/services/commander_attendance.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from services.attendance_merge import merge_attendance_records
+from utils.names import format_full_name
 
 
 def build_commander_roster(
@@ -30,11 +31,35 @@ def build_commander_roster(
 
     roster.sort(
         key=lambda e: (
+            str(e["cadet"].get("name", "") or "").lower(),
             str(e["cadet"].get("last_name", "") or "").lower(),
             str(e["cadet"].get("first_name", "") or "").lower(),
         )
     )
     return roster
+
+
+def hydrate_cadet_names(
+    cadets: list[dict[str, Any]],
+    users_by_id: dict[Any, dict[str, Any]],
+) -> list[dict[str, Any]]:
+    hydrated: list[dict[str, Any]] = []
+    for cadet in cadets:
+        user_doc = users_by_id.get(cadet.get("user_id"))
+        if user_doc is None:
+            hydrated.append(cadet)
+            continue
+
+        full_name = format_full_name(user_doc)
+        if not full_name:
+            hydrated.append(cadet)
+            continue
+
+        hydrated_cadet = dict(cadet)
+        hydrated_cadet["name"] = full_name
+        hydrated.append(hydrated_cadet)
+
+    return hydrated
 
 
 def compute_upserts(

--- a/tests/test_attendance_modifications.py
+++ b/tests/test_attendance_modifications.py
@@ -1,0 +1,384 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+from bson import ObjectId
+
+import services.attendance_modifications as modifications
+
+
+class _FakeAuditCollection:
+    def __init__(self, docs: list[dict] | None = None) -> None:
+        self.docs = [dict(doc) for doc in (docs or [])]
+        self.inserted: list[dict] = []
+
+    def find(self, query: dict) -> list[dict]:
+        return [dict(doc) for doc in self.docs if _matches(doc, query)]
+
+    def find_one(self, query: dict) -> dict | None:
+        for doc in self.docs:
+            if _matches(doc, query):
+                return dict(doc)
+        return None
+
+    def insert_one(self, doc: dict):
+        stored = dict(doc)
+        stored.setdefault("_id", ObjectId())
+        self.docs.append(stored)
+        self.inserted.append(stored)
+        return SimpleNamespace(inserted_id=stored["_id"])
+
+
+def _matches(doc: dict, query: dict) -> bool:
+    for key, value in query.items():
+        if doc.get(key) != value:
+            return False
+    return True
+
+
+def test_apply_bulk_attendance_changes_logs_saved_rows(monkeypatch):
+    log_calls: list[dict] = []
+    record_id = ObjectId()
+
+    monkeypatch.setattr(
+        modifications,
+        "_set_attendance_state",
+        lambda **kwargs: (
+            {"_id": record_id, "status": "present"},
+            {"_id": record_id, "status": kwargs["status"]},
+        ),
+    )
+    monkeypatch.setattr(
+        modifications,
+        "log_attendance_modification",
+        lambda **kwargs: log_calls.append(kwargs),
+    )
+
+    roster = [
+        {
+            "cadet": {"_id": "c1"},
+            "record": {"_id": record_id, "status": "present"},
+            "current_status": "present",
+        }
+    ]
+
+    result = modifications.apply_bulk_attendance_changes(
+        event_id=ObjectId(),
+        roster=roster,
+        new_statuses={"c1": "absent"},
+        recorded_by_user_id=ObjectId(),
+        recorded_by_roles=["cadre"],
+    )
+
+    assert result["changed_count"] == 1
+    assert len(log_calls) == 1
+    assert log_calls[0]["outcome"] == "applied"
+    assert log_calls[0]["old_status"] == "present"
+    assert log_calls[0]["new_status"] == "absent"
+    assert log_calls[0]["metadata"]["record_operation"] == "update"
+    assert log_calls[0]["metadata"]["batch_id"]
+
+
+def test_get_event_change_history_paginates_results(monkeypatch):
+    event_id = ObjectId()
+    actor_id = ObjectId()
+    now = datetime(2026, 4, 22, 12, 0, 0, tzinfo=timezone.utc)
+    cadet_ids = [ObjectId(), ObjectId(), ObjectId()]
+    cadet_user_ids = [ObjectId(), ObjectId(), ObjectId()]
+    docs = [
+        {
+            "_id": ObjectId(),
+            "source": "attendance_modification",
+            "event_id": event_id,
+            "cadet_id": cadet_ids[offset],
+            "user_id": actor_id,
+            "outcome": "applied",
+            "created_at": now - timedelta(minutes=offset),
+            "metadata": {"old_status": "present", "new_status": "absent"},
+        }
+        for offset in (0, 1, 2)
+    ]
+    fake = _FakeAuditCollection(docs)
+
+    monkeypatch.setattr(
+        modifications,
+        "get_collection",
+        lambda name: fake if name == "audit_log" else None,
+    )
+    monkeypatch.setattr(
+        modifications,
+        "get_cadets_by_ids",
+        lambda ids: [
+            {"_id": cadet_id, "user_id": cadet_user_id}
+            for cadet_id, cadet_user_id in zip(cadet_ids, cadet_user_ids)
+        ],
+    )
+    monkeypatch.setattr(
+        modifications,
+        "get_users_by_ids",
+        lambda ids: (
+            [
+                {
+                    "_id": cadet_user_ids[0],
+                    "first_name": "Casey",
+                    "last_name": "Cadet",
+                },
+                {
+                    "_id": cadet_user_ids[1],
+                    "first_name": "Morgan",
+                    "last_name": "Cadet",
+                },
+                {
+                    "_id": cadet_user_ids[2],
+                    "first_name": "Jordan",
+                    "last_name": "Cadet",
+                },
+                {"_id": actor_id, "first_name": "Chris", "last_name": "Cadre"},
+            ]
+        ),
+    )
+
+    history = modifications.get_event_change_history(event_id, page=2, page_size=2)
+
+    assert history["page"] == 2
+    assert history["total_pages"] == 2
+    assert history["total_count"] == 3
+    assert len(history["items"]) == 1
+    assert history["items"][0]["cadet_name"] == "Jordan Cadet"
+    assert history["items"][0]["changed_by"] == "Chris Cadre"
+
+
+def test_get_event_change_history_hides_superseded_actions(monkeypatch):
+    event_id = ObjectId()
+    cadet_id = ObjectId()
+    actor_id = ObjectId()
+    cadet_user_id = ObjectId()
+    now = datetime(2026, 4, 22, 12, 0, 0, tzinfo=timezone.utc)
+    fake = _FakeAuditCollection(
+        [
+            {
+                "_id": ObjectId(),
+                "source": "attendance_modification",
+                "event_id": event_id,
+                "cadet_id": cadet_id,
+                "user_id": actor_id,
+                "outcome": "undo",
+                "created_at": now,
+                "metadata": {"old_status": "present", "new_status": "absent"},
+            },
+            {
+                "_id": ObjectId(),
+                "source": "attendance_modification",
+                "event_id": event_id,
+                "cadet_id": cadet_id,
+                "user_id": actor_id,
+                "outcome": "applied",
+                "created_at": now - timedelta(minutes=1),
+                "metadata": {"old_status": "absent", "new_status": "present"},
+            },
+        ]
+    )
+
+    monkeypatch.setattr(
+        modifications,
+        "get_collection",
+        lambda name: fake if name == "audit_log" else None,
+    )
+    monkeypatch.setattr(
+        modifications,
+        "get_cadets_by_ids",
+        lambda ids: [{"_id": cadet_id, "user_id": cadet_user_id}],
+    )
+    monkeypatch.setattr(
+        modifications,
+        "get_users_by_ids",
+        lambda ids: [
+            {"_id": cadet_user_id, "first_name": "Taylor", "last_name": "Cadet"},
+            {"_id": actor_id, "first_name": "Jordan", "last_name": "Cadre"},
+        ],
+    )
+    monkeypatch.setattr(
+        modifications,
+        "get_attendance_record_by_event_cadet",
+        lambda event, cadet: {"_id": ObjectId(), "status": "absent"},
+    )
+
+    history = modifications.get_event_change_history(event_id, page=1, page_size=10)
+
+    assert history["total_count"] == 1
+    assert len(history["items"]) == 1
+    assert history["items"][0]["action"] == "Undo"
+    assert history["items"][0]["can_redo"] is True
+
+
+def test_get_event_change_history_marks_latest_saved_change_undoable(monkeypatch):
+    event_id = ObjectId()
+    cadet_id = ObjectId()
+    actor_id = ObjectId()
+    cadet_user_id = ObjectId()
+    change_id = ObjectId()
+    now = datetime(2026, 4, 22, 12, 0, 0, tzinfo=timezone.utc)
+    fake = _FakeAuditCollection(
+        [
+            {
+                "_id": change_id,
+                "source": "attendance_modification",
+                "event_id": event_id,
+                "cadet_id": cadet_id,
+                "user_id": actor_id,
+                "outcome": "applied",
+                "created_at": now,
+                "metadata": {"old_status": "present", "new_status": "absent"},
+            }
+        ]
+    )
+
+    monkeypatch.setattr(
+        modifications,
+        "get_collection",
+        lambda name: fake if name == "audit_log" else None,
+    )
+    monkeypatch.setattr(
+        modifications,
+        "get_cadets_by_ids",
+        lambda ids: [{"_id": cadet_id, "user_id": cadet_user_id}],
+    )
+    monkeypatch.setattr(
+        modifications,
+        "get_users_by_ids",
+        lambda ids: [
+            {"_id": cadet_user_id, "first_name": "Taylor", "last_name": "Cadet"},
+            {"_id": actor_id, "first_name": "Jordan", "last_name": "Cadre"},
+        ],
+    )
+    monkeypatch.setattr(
+        modifications,
+        "get_attendance_record_by_event_cadet",
+        lambda event, cadet: {"_id": ObjectId(), "status": "absent"},
+    )
+    monkeypatch.setattr(
+        modifications,
+        "get_waiver_by_attendance_record",
+        lambda record_id: None,
+    )
+
+    history = modifications.get_event_change_history(event_id, page=1, page_size=10)
+
+    assert len(history["items"]) == 1
+    item = history["items"][0]
+    assert item["change_id"] == str(change_id)
+    assert item["can_undo"] is True
+    assert item["can_redo"] is False
+    assert item["undo_target_label"] == "Present"
+
+
+def test_undo_change_blocks_when_reverting_to_no_record_with_waiver(monkeypatch):
+    event_id = ObjectId()
+    cadet_id = ObjectId()
+    change_id = ObjectId()
+    current_record_id = ObjectId()
+    fake = _FakeAuditCollection(
+        [
+            {
+                "_id": change_id,
+                "source": "attendance_modification",
+                "event_id": event_id,
+                "cadet_id": cadet_id,
+                "user_id": ObjectId(),
+                "outcome": "applied",
+                "created_at": datetime(2026, 4, 22, 12, 0, 0, tzinfo=timezone.utc),
+                "metadata": {"old_status": None, "new_status": "absent"},
+            }
+        ]
+    )
+
+    monkeypatch.setattr(
+        modifications,
+        "get_collection",
+        lambda name: fake if name == "audit_log" else None,
+    )
+    monkeypatch.setattr(
+        modifications,
+        "get_attendance_record_by_event_cadet",
+        lambda event, cadet: {"_id": current_record_id, "status": "absent"},
+    )
+    monkeypatch.setattr(
+        modifications,
+        "get_waiver_by_attendance_record",
+        lambda record_id: {"_id": ObjectId()},
+    )
+
+    ok, message = modifications.undo_change(
+        change_id,
+        recorded_by_user_id=ObjectId(),
+        recorded_by_roles=["cadre"],
+    )
+
+    assert ok is False
+    assert "waiver attached" in message
+
+
+def test_redo_change_reapplies_latest_undo(monkeypatch):
+    event_id = ObjectId()
+    cadet_id = ObjectId()
+    change_id = ObjectId()
+    captured_statuses: list[str | None] = []
+    logged: list[dict] = []
+    fake = _FakeAuditCollection(
+        [
+            {
+                "_id": change_id,
+                "source": "attendance_modification",
+                "event_id": event_id,
+                "cadet_id": cadet_id,
+                "user_id": ObjectId(),
+                "outcome": "undo",
+                "created_at": datetime(2026, 4, 22, 12, 0, 0, tzinfo=timezone.utc),
+                "metadata": {"old_status": "present", "new_status": "absent"},
+            }
+        ]
+    )
+
+    monkeypatch.setattr(
+        modifications,
+        "get_collection",
+        lambda name: fake if name == "audit_log" else None,
+    )
+    monkeypatch.setattr(
+        modifications,
+        "get_attendance_record_by_event_cadet",
+        lambda event, cadet: {"_id": ObjectId(), "status": "absent"},
+    )
+
+    def _fake_set_attendance_state(**kwargs):
+        captured_statuses.append(kwargs["status"])
+        return (
+            {"_id": ObjectId(), "status": "absent"},
+            {"_id": ObjectId(), "status": kwargs["status"]},
+        )
+
+    monkeypatch.setattr(
+        modifications,
+        "_set_attendance_state",
+        _fake_set_attendance_state,
+    )
+    monkeypatch.setattr(
+        modifications,
+        "log_attendance_modification",
+        lambda **kwargs: logged.append(kwargs),
+    )
+
+    ok, message = modifications.redo_change(
+        change_id,
+        recorded_by_user_id=ObjectId(),
+        recorded_by_roles=["cadre"],
+    )
+
+    assert ok is True
+    assert message == "Attendance change redone."
+    assert captured_statuses == ["present"]
+    assert logged[0]["outcome"] == "redo"
+    assert logged[0]["old_status"] == "absent"
+    assert logged[0]["new_status"] == "present"
+    assert logged[0]["metadata"]["redoes_audit_id"] == str(change_id)

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -74,3 +74,37 @@ def test_log_checkin_attempt_converts_string_ids_to_object_ids(monkeypatch):
     assert doc["cadet_id"] == cadet_id
     assert doc["event_id"] == event_id
     assert doc["user_id"] == user_id
+
+
+def test_log_attendance_modification_writes_expected_fields(monkeypatch):
+    fake = _FakeCollection()
+    monkeypatch.setattr(audit_log, "get_collection", lambda name: fake)
+
+    event_id = ObjectId()
+    cadet_id = ObjectId()
+    user_id = ObjectId()
+    now = datetime(2026, 4, 22, 15, 30, 0, tzinfo=timezone.utc)
+
+    audit_log.log_attendance_modification(
+        event_id=event_id,
+        cadet_id=cadet_id,
+        user_id=user_id,
+        outcome="undo",
+        old_status="present",
+        new_status=None,
+        now=now,
+        metadata={"reverts_audit_id": str(ObjectId())},
+    )
+
+    assert len(fake.inserted) == 1
+    doc = fake.inserted[0]
+
+    assert doc["created_at"] == now
+    assert doc["event_id"] == event_id
+    assert doc["cadet_id"] == cadet_id
+    assert doc["user_id"] == user_id
+    assert doc["outcome"] == "undo"
+    assert doc["source"] == "attendance_modification"
+    assert doc["metadata"]["old_status"] == "present"
+    assert doc["metadata"]["new_status"] is None
+    assert "reverts_audit_id" in doc["metadata"]

--- a/utils/audit_log.py
+++ b/utils/audit_log.py
@@ -61,3 +61,40 @@ def log_checkin_attempt(
         doc["metadata"] = dict(metadata)
 
     return col.insert_one(doc)
+
+
+def log_attendance_modification(
+    *,
+    event_id: str | ObjectId,
+    cadet_id: str | ObjectId,
+    user_id: str | ObjectId,
+    outcome: str,
+    old_status: str | None,
+    new_status: str | None,
+    source: str = "attendance_modification",
+    now: datetime | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> InsertOneResult | None:
+    """Write an attendance modification audit entry."""
+
+    col = get_collection("audit_log")
+    if col is None:
+        return None
+
+    doc: dict[str, Any] = {
+        "created_at": now or _utcnow(),
+        "event_id": ObjectId(event_id),
+        "cadet_id": ObjectId(cadet_id),
+        "user_id": ObjectId(user_id),
+        "outcome": str(outcome),
+        "source": str(source),
+        "metadata": {
+            "old_status": old_status,
+            "new_status": new_status,
+        },
+    }
+
+    if metadata:
+        doc["metadata"].update(dict(metadata))
+
+    return col.insert_one(doc)

--- a/utils/create_indexes.py
+++ b/utils/create_indexes.py
@@ -106,6 +106,19 @@ def create_indexes() -> None:
                 [("source", ASCENDING), ("created_at", ASCENDING)],
                 name="source_created_at",
             ),
+            IndexModel(
+                [("source", ASCENDING), ("event_id", ASCENDING), ("created_at", ASCENDING)],
+                name="source_event_created_at",
+            ),
+            IndexModel(
+                [
+                    ("source", ASCENDING),
+                    ("event_id", ASCENDING),
+                    ("cadet_id", ASCENDING),
+                    ("created_at", ASCENDING),
+                ],
+                name="source_event_cadet_created_at",
+            ),
         ]
     )
 

--- a/utils/db_schema_crud.py
+++ b/utils/db_schema_crud.py
@@ -117,6 +117,14 @@ def get_all_cadets() -> list[dict]:
     return list(col.find())
 
 
+def get_cadets_by_ids(cadet_ids: list[str | ObjectId]) -> list[dict]:
+    col = get_collection("cadets")
+    if col is None or not cadet_ids:
+        return []
+    object_ids = [ObjectId(cadet_id) for cadet_id in cadet_ids]
+    return list(col.find({"_id": {"$in": object_ids}}))
+
+
 def get_cadet_by_user_id(user_id: str | ObjectId) -> dict | None:
     col = get_collection("cadets")
     if col is None:
@@ -348,6 +356,21 @@ def get_attendance_by_cadet(cadet_id: str | ObjectId) -> list[dict]:
     if col is None:
         return []
     return list(col.find({"cadet_id": ObjectId(cadet_id)}))
+
+
+def get_attendance_record_by_event_cadet(
+    event_id: str | ObjectId,
+    cadet_id: str | ObjectId,
+) -> dict | None:
+    col = get_collection("attendance_records")
+    if col is None:
+        return None
+    return col.find_one(
+        {
+            "event_id": ObjectId(event_id),
+            "cadet_id": ObjectId(cadet_id),
+        }
+    )
 
 
 def upsert_attendance_record(


### PR DESCRIPTION
This PR adds audit-backed attendance modification tracking to the Modify Attendance flow, with save/undo/redo logic in dedicated services and recording each manual attendance change in audit_log with the prior and new status. It also updates the commander attendance page to surface a paginated Recent Changes table for the selected event, show the current available follow-up action, and support undo/redo of the latest modifications with inline confirmation and feedback. supporting tests were added to cover the new history and reversal behavior.

closes #231 