### PR TITLE
shared pagination util

### DIFF
--- a/pages/10_Commander_Attendance.py
+++ b/pages/10_Commander_Attendance.py
@@ -15,7 +15,10 @@ from services.attendance_modifications import (
     redo_change,
     undo_change,
 )
-from services.commander_attendance import build_commander_roster, hydrate_cadet_names
+from services.commander_attendance import (
+    get_paginated_commander_roster,
+    get_roster_entries_for_cadet_ids,
+)
 from services.events import closest_event_index, get_all_events, has_event_ended
 from utils.auth import get_current_user, require_role
 from utils.st_helpers import require
@@ -24,16 +27,13 @@ from utils.attendance_status import (
     get_attendance_status_cell_style,
     get_attendance_status_label,
 )
+from utils.pagination import init_pagination_state, render_pagination_controls, sync_pagination_state
 from utils.db_schema_crud import (
-    get_all_cadets,
-    get_attendance_by_event,
     get_user_by_email,
-    get_users_by_ids,
 )
 
 STATUS_OPTIONS = [NO_RECORD_STATUS_LABEL, "Present", "Absent", "Excused"]
 STATUS_TO_DB = {"Present": "present", "Absent": "absent", "Excused": "excused"}
-HISTORY_PAGE_SIZE = 10
 
 require_role("admin", "cadre")
 st.title("Modify Attendance")
@@ -68,10 +68,18 @@ def _sync_history_state(event_id: str) -> None:
         return
 
     st.session_state["_attendance_history_event_id"] = event_id
-    st.session_state["_attendance_history_page"] = 1
     st.session_state["_attendance_selected_change_id"] = None
     st.session_state["_attendance_recent_changes_table_version"] = 0
     st.session_state["_attendance_recent_changes_feedback"] = None
+
+
+def _sync_roster_state(event_id: str) -> None:
+    previous_event_id = st.session_state.get("_attendance_roster_event_id")
+    if previous_event_id == event_id:
+        return
+
+    st.session_state["_attendance_roster_event_id"] = event_id
+    st.session_state["_attendance_roster_drafts"] = {}
 
 
 def _recent_changes_table_key() -> str:
@@ -98,6 +106,28 @@ def _set_recent_changes_feedback(kind: str, message: str) -> None:
 
 def _clear_recent_changes_feedback() -> None:
     st.session_state["_attendance_recent_changes_feedback"] = None
+
+
+def _sync_roster_drafts(
+    edited: pd.DataFrame,
+    roster: list[dict[str, Any]],
+    *,
+    default_status: str,
+) -> None:
+    drafts = dict(st.session_state.get("_attendance_roster_drafts", {}))
+    for idx, (_, row) in enumerate(edited.iterrows()):
+        cadet_id = str(roster[idx]["cadet"]["_id"])
+        current_label = get_attendance_status_label(
+            roster[idx]["current_status"],
+            default=default_status,
+        )
+        selected_label = str(row["Set Status"])
+        if selected_label == current_label:
+            drafts.pop(cadet_id, None)
+        else:
+            drafts[cadet_id] = selected_label
+
+    st.session_state["_attendance_roster_drafts"] = drafts
 
 
 def _show_recent_changes_feedback() -> None:
@@ -157,111 +187,157 @@ event_id: str = selected_event["_id"]
 event_has_ended = has_event_ended(selected_event)
 default_status = "Absent" if event_has_ended else NO_RECORD_STATUS_LABEL
 _sync_history_state(str(event_id))
+_sync_roster_state(str(event_id))
 
-all_cadets = get_all_cadets()
-if not all_cadets:
-    st.info("No cadets found.")
-    st.stop()
+st.subheader("Attendance Roster")
 
-cadet_user_ids = [c["user_id"] for c in all_cadets if c.get("user_id") is not None]
-user_by_id = {user["_id"]: user for user in get_users_by_ids(cadet_user_ids)}
-all_cadets = hydrate_cadet_names(all_cadets, user_by_id)
-
-records = get_attendance_by_event(event_id)
-roster = build_commander_roster(all_cadets, records)
-
-cadet_ids = [str(entry["cadet"]["_id"]) for entry in roster]
-initial_statuses = [
-    get_attendance_status_label(entry["current_status"], default=default_status)
-    for entry in roster
-]
-
-df = pd.DataFrame(
-    {
-        "Cadet": [
-            str(e["cadet"].get("name", "") or "").strip()
-            or f"{str(e['cadet'].get('last_name', '') or '').strip()}, "
-            f"{str(e['cadet'].get('first_name', '') or '').strip()}".strip(", ")
-            or "Unknown"
-            for e in roster
-        ],
-        "Current Status": initial_statuses,
-        "Set Status": initial_statuses,
-    }
-)
-
-styler = df.style
-if hasattr(styler, "map"):
-    styler = styler.map(get_attendance_status_cell_style, subset=["Current Status"])
-else:
-    styler = styler.applymap(
-        get_attendance_status_cell_style,
-        subset=["Current Status"],
+@st.fragment
+def _render_attendance_roster() -> None:
+    roster_page, roster_page_size = init_pagination_state(
+        "attendance_roster",
+        reset_token=str(event_id),
     )
+    roster_page_data = get_paginated_commander_roster(
+        event_id,
+        page=roster_page,
+        page_size=roster_page_size,
+    )
+    sync_pagination_state("attendance_roster", roster_page_data)
 
-edited = st.data_editor(
-    styler,
-    column_config={
-        "Cadet": st.column_config.TextColumn(disabled=True),
-        "Current Status": st.column_config.TextColumn(disabled=True),
-        "Set Status": st.column_config.SelectboxColumn(
-            options=STATUS_OPTIONS, required=True
-        ),
-    },
-    hide_index=True,
-    width="stretch",
-)
+    roster = list(roster_page_data["items"])
+    if not roster:
+        st.info("No cadets found.")
+        return
 
-st.divider()
-if st.button("Save All", type="primary"):
-    invalid_no_record_rows = [
-        roster[idx]["cadet"]
-        for idx, (_, row) in enumerate(edited.iterrows())
-        if row["Set Status"] == NO_RECORD_STATUS_LABEL
-        and roster[idx]["record"] is not None
+    draft_statuses = dict(st.session_state.get("_attendance_roster_drafts", {}))
+    current_statuses = [
+        get_attendance_status_label(entry["current_status"], default=default_status)
+        for entry in roster
     ]
-    if invalid_no_record_rows:
-        st.error(
-            "No Record can only be used for cadets who do not already have an attendance entry."
-        )
-        st.stop()
+    selected_statuses = [
+        draft_statuses.get(str(entry["cadet"]["_id"]), current_statuses[idx])
+        for idx, entry in enumerate(roster)
+    ]
 
-    new_statuses = {
-        cadet_ids[idx]: STATUS_TO_DB[row["Set Status"]]
-        for idx, (_, row) in enumerate(edited.iterrows())
-        if row["Set Status"] != initial_statuses[idx]
-        and row["Set Status"] in STATUS_TO_DB
-    }
-    save_result = apply_bulk_attendance_changes(
-        event_id=event_id,
-        roster=roster,
-        new_statuses=new_statuses,
-        recorded_by_user_id=user["_id"],
-        recorded_by_roles=list(user.get("roles", [])),
+    df = pd.DataFrame(
+        {
+            "Cadet": [
+                str(entry["cadet"].get("name", "") or "").strip()
+                or f"{str(entry['cadet'].get('last_name', '') or '').strip()}, "
+                f"{str(entry['cadet'].get('first_name', '') or '').strip()}".strip(", ")
+                or "Unknown"
+                for entry in roster
+            ],
+            "Current Status": current_statuses,
+            "Set Status": selected_statuses,
+        }
     )
-    if save_result["changed_count"] == 0:
-        _set_feedback("info", "No attendance changes to save.")
+
+    styler = df.style
+    if hasattr(styler, "map"):
+        styler = styler.map(get_attendance_status_cell_style, subset=["Current Status"])
     else:
-        st.session_state["_attendance_history_page"] = 1
-        _reset_recent_changes_selection()
-        _clear_recent_changes_feedback()
-        _set_feedback(
-            "success",
-            f"Saved attendance for {save_result['changed_count']} cadet(s).",
+        styler = styler.applymap(
+            get_attendance_status_cell_style,
+            subset=["Current Status"],
         )
-    st.rerun()
+
+    edited = st.data_editor(
+        styler,
+        column_config={
+            "Cadet": st.column_config.TextColumn(disabled=True),
+            "Current Status": st.column_config.TextColumn(disabled=True),
+            "Set Status": st.column_config.SelectboxColumn(
+                options=STATUS_OPTIONS,
+                required=True,
+            ),
+        },
+        hide_index=True,
+        width="stretch",
+        key=(
+            f"attendance_roster_editor_"
+            f"{event_id}_{roster_page_data['page']}_{roster_page_data['page_size']}"
+        ),
+    )
+    _sync_roster_drafts(edited, roster, default_status=default_status)
+
+    render_pagination_controls(
+        "attendance_roster",
+        roster_page_data,
+        rerun_scope="fragment",
+    )
+
+    st.divider()
+    if st.button("Save All", type="primary", key="attendance_roster_save_all"):
+        _sync_roster_drafts(edited, roster, default_status=default_status)
+        drafts = dict(st.session_state.get("_attendance_roster_drafts", {}))
+        if not drafts:
+            _set_feedback("info", "No attendance changes to save.")
+            st.rerun()
+
+        draft_cadet_ids = list(drafts.keys())
+        roster_to_save = get_roster_entries_for_cadet_ids(event_id, draft_cadet_ids)
+        if not roster_to_save:
+            _set_feedback("error", "Could not load attendance roster for the selected edits.")
+            st.rerun()
+
+        invalid_no_record_rows = [
+            entry["cadet"]
+            for entry in roster_to_save
+            if drafts.get(str(entry["cadet"]["_id"])) == NO_RECORD_STATUS_LABEL
+            and entry["record"] is not None
+        ]
+        if invalid_no_record_rows:
+            st.error(
+                "No Record can only be used for cadets who do not already have an attendance entry."
+            )
+            st.stop()
+
+        new_statuses = {
+            str(entry["cadet"]["_id"]): STATUS_TO_DB[
+                drafts[str(entry["cadet"]["_id"])]
+            ]
+            for entry in roster_to_save
+            if drafts.get(str(entry["cadet"]["_id"])) in STATUS_TO_DB
+        }
+        save_result = apply_bulk_attendance_changes(
+            event_id=event_id,
+            roster=roster_to_save,
+            new_statuses=new_statuses,
+            recorded_by_user_id=user["_id"],
+            recorded_by_roles=list(user.get("roles", [])),
+        )
+        if save_result["changed_count"] == 0:
+            _set_feedback("info", "No attendance changes to save.")
+        else:
+            st.session_state["_attendance_roster_drafts"] = {}
+            st.session_state["attendance_history_page"] = 1
+            _reset_recent_changes_selection()
+            _clear_recent_changes_feedback()
+            _set_feedback(
+                "success",
+                f"Saved attendance for {save_result['changed_count']} cadet(s).",
+            )
+        st.rerun()
+
+
+_render_attendance_roster()
 
 st.subheader("Recent Changes")
 
 
 @st.fragment
 def _render_recent_changes() -> None:
-    history_page = int(st.session_state.get("_attendance_history_page", 1) or 1)
+    history_page, history_page_size = init_pagination_state(
+        "attendance_history",
+        reset_token=str(event_id),
+    )
     history = get_event_change_history(
         event_id,
         page=history_page,
-        page_size=HISTORY_PAGE_SIZE,
+        page_size=history_page_size,
     )
+    sync_pagination_state("attendance_history", history)
 
     if not history["items"]:
         st.caption("No saved attendance changes yet for this event.")
@@ -330,7 +406,7 @@ def _render_recent_changes() -> None:
                         recorded_by_roles=list(user.get("roles", [])),
                     )
                     if ok:
-                        st.session_state["_attendance_history_page"] = 1
+                        st.session_state["attendance_history_page"] = 1
                         _reset_recent_changes_selection()
                     _set_recent_changes_feedback(
                         "success" if ok else "error",
@@ -353,7 +429,7 @@ def _render_recent_changes() -> None:
                         recorded_by_roles=list(user.get("roles", [])),
                     )
                     if ok:
-                        st.session_state["_attendance_history_page"] = 1
+                        st.session_state["attendance_history_page"] = 1
                         _reset_recent_changes_selection()
                     _set_recent_changes_feedback(
                         "success" if ok else "error",
@@ -364,31 +440,11 @@ def _render_recent_changes() -> None:
                 st.caption(selected_item["action_block_reason"])
 
         st.divider()
-        page_col, prev_col, next_col = st.columns([3, 1, 1])
-        page_col.caption(
-            f"Page {history['page']} of {history['total_pages']}"
-            f" • {history['total_count']} total change(s)"
+        render_pagination_controls(
+            "attendance_history",
+            history,
+            rerun_scope="fragment",
         )
-        if prev_col.button(
-            "Previous",
-            key="attendance_history_prev",
-            disabled=history["page"] <= 1,
-            width="stretch",
-        ):
-            st.session_state["_attendance_history_page"] = history["page"] - 1
-            _reset_recent_changes_selection()
-            _clear_recent_changes_feedback()
-            st.rerun(scope="fragment")
-        if next_col.button(
-            "Next",
-            key="attendance_history_next",
-            disabled=history["page"] >= history["total_pages"],
-            width="stretch",
-        ):
-            st.session_state["_attendance_history_page"] = history["page"] + 1
-            _reset_recent_changes_selection()
-            _clear_recent_changes_feedback()
-            st.rerun(scope="fragment")
 
 
 _render_recent_changes()

--- a/pages/1_Dashboard.py
+++ b/pages/1_Dashboard.py
@@ -17,12 +17,16 @@ from utils.attendance_status import (
 )
 from utils.db import get_collection, get_db
 from utils.export import to_excel
+from utils.pagination import (
+    build_pagination_metadata,
+    init_pagination_state,
+    paginate_list,
+    render_pagination_controls,
+    sync_pagination_state,
+)
 
 
 require_role("admin", "cadre", "flight_commander")
-
-
-_MAX_EVENTS = 200
 
 
 def _utc_datetime(d: date, end_of_day: bool) -> datetime:
@@ -187,7 +191,24 @@ if event_type_choice == "PT":
 elif event_type_choice == "LLAB":
     event_query["event_type"] = "lab"
 
-total_event_count = events_col.count_documents({})
+event_pagination_reset_token = "|".join(
+    [
+        start_dt.isoformat(),
+        end_dt.isoformat(),
+        event_type_choice,
+        selected_flight_name,
+    ]
+)
+event_page, event_page_size = init_pagination_state(
+    "dashboard_events",
+    reset_token=event_pagination_reset_token,
+)
+total_event_count = int(events_col.count_documents(event_query))
+event_pagination = build_pagination_metadata(
+    page=event_page,
+    page_size=event_page_size,
+    total_count=total_event_count,
+)
 
 event_docs = list(
     events_col.find(
@@ -195,10 +216,11 @@ event_docs = list(
         {"_id": 1, "start_date": 1, "event_name": 1, "event_type": 1},
     )
     .sort("start_date", -1)
-    .limit(_MAX_EVENTS)
+    .skip(event_pagination["skip"])
+    .limit(event_pagination["page_size"])
 )
-
-too_many_events = total_event_count > _MAX_EVENTS
+event_pagination = {**event_pagination, "items": event_docs}
+sync_pagination_state("dashboard_events", event_pagination)
 
 if not event_docs:
     st.info("No events found for the selected filters.")
@@ -239,11 +261,7 @@ else:
         # --- Event summary (one row per event)
 
         st.subheader("Event Summary")
-        st.caption(f"Showing {len(event_docs)}/{total_event_count} events")
-        if too_many_events:
-            st.warning(
-                f"Showing newest {_MAX_EVENTS} of {total_event_count} events. Narrow the date range to see older events."
-            )
+        st.caption(f"Showing {len(event_docs)} event(s) on this page.")
 
         # Aggregate counts by event_id and status. Prefer doing this server-side.
         status_counts: dict[ObjectId, dict[str, int]] = {
@@ -314,18 +332,25 @@ else:
                 width="stretch",
                 hide_index=True,
             )
+            render_pagination_controls("dashboard_events", event_pagination)
 
-            _summary_events = [
-                event_by_id.get(eid, {}) for eid in summary_df["_event_id"]
-            ]
-            selected_label = st.selectbox(
+            summary_event_ids = list(summary_df["_event_id"])
+            if (
+                "dashboard_selected_event_id" not in st.session_state
+                or st.session_state["dashboard_selected_event_id"] not in summary_event_ids
+            ):
+                _summary_events = [event_by_id.get(eid, {}) for eid in summary_event_ids]
+                default_index = closest_event_index(_summary_events)
+                st.session_state["dashboard_selected_event_id"] = summary_event_ids[
+                    default_index
+                ]
+
+            selected_event_id = st.selectbox(
                 "Select an event to view cadets",
-                options=list(summary_df["Event"]),
-                index=closest_event_index(_summary_events),
+                options=summary_event_ids,
+                format_func=lambda eid: _event_label(event_by_id.get(eid, {})),
+                key="dashboard_selected_event_id",
             )
-
-            selected_row = summary_df.loc[summary_df["Event"] == selected_label].iloc[0]
-            selected_event_id = selected_row["_event_id"]
             selected_event = event_by_id.get(selected_event_id)
 
             st.subheader("Cadets for Selected Event")
@@ -357,7 +382,26 @@ else:
                 if not cadet_rows:
                     st.info("No cadets match the current status filter.")
                 else:
-                    cadet_df = pd.DataFrame(cadet_rows)
+                    cadet_pagination_reset_token = "|".join(
+                        [
+                            str(selected_event_id),
+                            status_choice,
+                            selected_flight_name,
+                        ]
+                    )
+                    cadet_page, cadet_page_size = init_pagination_state(
+                        "dashboard_cadets",
+                        reset_token=cadet_pagination_reset_token,
+                    )
+                    paginated_cadets = paginate_list(
+                        cadet_rows,
+                        page=cadet_page,
+                        page_size=cadet_page_size,
+                    )
+                    sync_pagination_state("dashboard_cadets", paginated_cadets)
+
+                    cadet_df = pd.DataFrame(paginated_cadets["items"])
+                    export_cadet_df = pd.DataFrame(cadet_rows)
                     styler = cadet_df.style
                     if hasattr(styler, "map"):
                         styler = styler.map(
@@ -371,16 +415,16 @@ else:
                         )
 
                     col1, col2, spacer = st.columns([1.5, 2, 10])
-                    if isinstance(cadet_df, pd.DataFrame):
+                    if isinstance(export_cadet_df, pd.DataFrame):
                         col1.download_button(
                             "Export CSV",
-                            cadet_df.to_csv().encode("utf-8"),
+                            export_cadet_df.to_csv(index=False).encode("utf-8"),
                             "attendance.csv",
                             "text/csv",
                         )
                         col2.download_button(
                             "Export Excel",
-                            to_excel(cadet_df),
+                            to_excel(export_cadet_df),
                             "attendance.xlsx",
                             "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
                         )
@@ -394,3 +438,4 @@ else:
                         st.warning("Excused")
 
                     st.dataframe(styler, width="stretch", hide_index=True)
+                    render_pagination_controls("dashboard_cadets", paginated_cadets)

--- a/pages/3_Cadets.py
+++ b/pages/3_Cadets.py
@@ -24,6 +24,12 @@ from services.cadets import (
 from services.account_settings import build_profile_updates
 
 from utils.export import to_excel
+from utils.pagination import (
+    init_pagination_state,
+    paginate_list,
+    render_pagination_controls,
+    sync_pagination_state,
+)
 
 
 require_role("admin", "cadre")
@@ -196,9 +202,11 @@ def show_cadets():
 
     rows: list[dict[str, str | int]] = []
     cadet_by_id: dict[str, dict] = {}
+    cadet_ids: list[str] = []
     for i, cadet in enumerate(cadets):
         cid = str(cadet.get("_id"))
         cadet_by_id[cid] = cadet
+        cadet_ids.append(cid)
 
         user_doc = None
         try:
@@ -219,11 +227,27 @@ def show_cadets():
             }
         )
 
-    df = pd.DataFrame(
+    cadet_page, cadet_page_size = init_pagination_state(
+        "cadet_management",
+        reset_token=str(len(cadets)),
+    )
+    paginated_rows = paginate_list(
         rows,
+        page=cadet_page,
+        page_size=cadet_page_size,
+    )
+    sync_pagination_state("cadet_management", paginated_rows)
+    page_rows = list(paginated_rows["items"])
+    page_ids = cadet_ids[
+        paginated_rows["skip"] : paginated_rows["skip"] + paginated_rows["page_size"]
+    ]
+
+    df = pd.DataFrame(
+        page_rows,
         columns=pd.Index(["No.", "First Name", "Last Name", "Email", "Rank"]),
     )
     st.dataframe(df, hide_index=True, width="stretch")
+    render_pagination_controls("cadet_management", paginated_rows)
 
     st.divider()
 
@@ -244,17 +268,16 @@ def show_cadets():
         name = f"{first} {last}".strip() or "Unknown"
         return f"{name} ({email})".strip()
 
-    cadet_ids = list(cadet_by_id.keys())
-    if not cadet_ids:
+    if not page_ids:
         return
 
     # Keep selection stable across reruns.
-    if st.session_state.selected_cadet_id not in cadet_by_id:
-        st.session_state.selected_cadet_id = cadet_ids[0]
+    if st.session_state.selected_cadet_id not in page_ids:
+        st.session_state.selected_cadet_id = page_ids[0]
 
     selected_id = st.selectbox(
         "Select cadet",
-        options=cadet_ids,
+        options=page_ids,
         format_func=_cadet_label,
         key="selected_cadet_id",
     )

--- a/pages/6_Waiver_Review.py
+++ b/pages/6_Waiver_Review.py
@@ -4,9 +4,9 @@ import pandas as pd
 
 from services.waiver_review import (
     get_flight_options,
-    get_waiver_context,
+    get_paginated_waiver_review_rows,
     get_waiver_export_df,
-    get_waivers,
+    get_waiver_review_rows,
     submit_decision,
 )
 from services.waivers import WAIVER_STATUS_BADGE
@@ -14,6 +14,7 @@ from services.waivers import WAIVER_STATUS_BADGE
 from utils.auth import get_current_user, require_role
 from utils.db_schema_crud import get_user_by_email
 from utils.export import to_excel
+from utils.pagination import init_pagination_state, render_pagination_controls, sync_pagination_state
 
 from utils.st_helpers import require
 
@@ -45,55 +46,34 @@ flight_filter = st.selectbox("Flight", get_flight_options(), index=0)
 cadet_search = st.text_input("Cadet search (name or email)", "").strip().lower()
 
 viewer_roles = list(current_user.get("roles") or [])
-waivers = get_waivers(status_filter.lower(), viewer_roles)
+pagination_reset_token = "|".join(
+    [
+        status_filter.lower(),
+        flight_filter,
+        cadet_search,
+        ",".join(sorted(viewer_roles)),
+    ]
+)
+review_page, review_page_size = init_pagination_state(
+    "waiver_review",
+    reset_token=pagination_reset_token,
+)
 
-if not waivers:
-    st.info("No waivers found for the selected filters.")
-    st.stop()
-
-rows = []
-for waiver in waivers:
-    waiver_id = waiver.get("_id")
-    if waiver_id is None:
-        continue
-
-    ctx = get_waiver_context(waiver)
-    if ctx is None:
-        continue
-
-    cadet_name = ctx["cadet_name"]
-    cadet_email = ctx["cadet_email"]
-    flight_name = ctx["flight_name"]
-    event_name = ctx["event_name"]
-    event_date = ctx["event_date"]
-    event_type = ctx["event_type"]
-    waiver_type = ctx["waiver_type"]
-    attachments = ctx["attachments"]
-    waiver_status = (waiver.get("status") or "pending").lower()
-
-    if flight_filter != "All flights" and flight_name != flight_filter:
-        continue
-
-    if cadet_search:
-        hay = f"{cadet_name} {cadet_email}".lower()
-        if cadet_search not in hay:
-            continue
-
-    rows.append(
-        {
-            "waiver_id": waiver_id,
-            "waiver_status": waiver_status,
-            "waiver_type": waiver_type,
-            "attachments": attachments,
-            "reason": waiver.get("reason", ""),
-            "cadet_name": cadet_name,
-            "cadet_email": cadet_email,
-            "flight_name": flight_name,
-            "event_name": event_name,
-            "event_date": event_date,
-            "event_type": event_type,
-        }
-    )
+rows = get_waiver_review_rows(
+    status_filter=status_filter.lower(),
+    flight_filter=flight_filter,
+    cadet_search=cadet_search,
+    viewer_roles=viewer_roles,
+)
+paginated_rows = get_paginated_waiver_review_rows(
+    status_filter=status_filter.lower(),
+    flight_filter=flight_filter,
+    cadet_search=cadet_search,
+    viewer_roles=viewer_roles,
+    page=review_page,
+    page_size=review_page_size,
+)
+sync_pagination_state("waiver_review", paginated_rows)
 
 export_df = get_waiver_export_df(rows)
 if isinstance(export_df, str):
@@ -104,7 +84,7 @@ if not rows:
     st.info("No waivers matched the selected filters.")
     st.stop()
 
-for w in rows:
+for w in paginated_rows["items"]:
     with st.container(border=True):
         top = st.columns([4, 2, 2])
         top[0].markdown(f"**{w['cadet_name']}**  \n{w['cadet_email']}")
@@ -164,6 +144,9 @@ for w in rows:
                         st.rerun()
                     else:
                         st.error(err)
+
+st.divider()
+render_pagination_controls("waiver_review", paginated_rows)
 
 st.divider()
 col1, col2, spacer = st.columns([2, 2, 10])

--- a/pages/8_User_Management.py
+++ b/pages/8_User_Management.py
@@ -15,6 +15,12 @@ from services.admin_users import (
     confirm_delete_user,
     ALLOWED_ROLES,
 )
+from utils.pagination import (
+    init_pagination_state,
+    paginate_list,
+    render_pagination_controls,
+    sync_pagination_state,
+)
 
 
 require_role("admin")
@@ -256,6 +262,18 @@ else:
     if not filtered:
         st.info("No users match your filters.")
     else:
+        users_page, users_page_size = init_pagination_state(
+            "admin_users",
+            reset_token=f"{role_filter}|{search_norm}",
+        )
+        paginated_filtered = paginate_list(
+            filtered,
+            page=users_page,
+            page_size=users_page_size,
+        )
+        sync_pagination_state("admin_users", paginated_filtered)
+        page_filtered = list(paginated_filtered["items"])
+
         df = pd.DataFrame(
             [
                 {
@@ -263,15 +281,16 @@ else:
                     "Email": s.get("email", ""),
                     "Role": s.get("role", "") or "-",
                 }
-                for s in filtered
+                for s in page_filtered
             ],
             columns=pd.Index(["Name", "Email", "Role"]),
         )
         st.dataframe(df, hide_index=True, width="stretch")
+        render_pagination_controls("admin_users", paginated_filtered)
 
-        filtered_ids = [s["id"] for s in filtered]
-        if st.session_state.admin_users_selected not in filtered_ids:
-            st.session_state.admin_users_selected = filtered_ids[0]
+        page_filtered_ids = [s["id"] for s in page_filtered]
+        if st.session_state.admin_users_selected not in page_filtered_ids:
+            st.session_state.admin_users_selected = page_filtered_ids[0]
 
         def _label(user_id: str) -> str:
             s = summary_by_id.get(user_id, {})
@@ -281,7 +300,7 @@ else:
 
         selected_id = st.selectbox(
             "Select user",
-            options=filtered_ids,
+            options=page_filtered_ids,
             format_func=_label,
             key="admin_users_selected",
         )

--- a/services/attendance_modifications.py
+++ b/services/attendance_modifications.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from math import ceil
 from typing import Any
 from uuid import uuid4
 
@@ -26,6 +25,7 @@ from utils.db_schema_crud import (
 )
 from utils.datetime_utils import ensure_utc
 from utils.names import format_full_name
+from utils.pagination import build_pagination_metadata, paginate_list
 
 
 _AUDIT_SOURCE = "attendance_modification"
@@ -159,6 +159,26 @@ def _latest_visible_event_change_docs(event_id: str | ObjectId) -> list[dict[str
         seen_cadet_ids.add(cadet_id)
         visible_docs.append(doc)
     return visible_docs
+
+
+def _latest_visible_event_change_pipeline(event_id: str | ObjectId) -> list[dict[str, Any]]:
+    return [
+        {
+            "$match": {
+                "source": _AUDIT_SOURCE,
+                "event_id": ObjectId(event_id),
+            }
+        },
+        {"$sort": {"created_at": -1, "_id": -1}},
+        {
+            "$group": {
+                "_id": "$cadet_id",
+                "doc": {"$first": "$$ROOT"},
+            }
+        },
+        {"$replaceRoot": {"newRoot": "$doc"}},
+        {"$sort": {"created_at": -1, "_id": -1}},
+    ]
 
 
 def _hydrate_changes(docs: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -297,25 +317,53 @@ def get_event_change_history(
     page: int = 1,
     page_size: int = 10,
 ) -> dict[str, Any]:
-    visible_docs = _latest_visible_event_change_docs(event_id)
-    total_count = len(visible_docs)
-    total_pages = max(1, ceil(total_count / page_size)) if page_size > 0 else 1
-    page = min(max(page, 1), total_pages)
-    start = (page - 1) * page_size
+    col = get_collection("audit_log")
+    docs: list[dict[str, Any]] = []
 
-    docs = visible_docs[start : start + page_size]
+    if col is not None and hasattr(col, "aggregate"):
+        base_pipeline = _latest_visible_event_change_pipeline(event_id)
+        count_docs = list(col.aggregate(base_pipeline + [{"$count": "total_count"}]))
+        total_count = int(count_docs[0]["total_count"]) if count_docs else 0
+        pagination = build_pagination_metadata(
+            page=page,
+            page_size=page_size,
+            total_count=total_count,
+        )
+        docs = list(
+            col.aggregate(
+                base_pipeline
+                + [
+                    {"$skip": pagination["skip"]},
+                    {"$limit": pagination["page_size"]},
+                ]
+            )
+        )
+    else:
+        paginated = paginate_list(
+            _latest_visible_event_change_docs(event_id),
+            page=page,
+            page_size=page_size,
+        )
+        pagination = {
+            key: paginated[key]
+            for key in ("page", "page_size", "total_count", "total_pages", "skip")
+        }
+        docs = list(paginated["items"])
+
     items = _hydrate_changes(docs)
     for doc, item in zip(docs, items):
-        latest_doc = _latest_pair_history_doc(doc["event_id"], doc["cadet_id"])
+        latest_doc = doc if col is not None and hasattr(col, "aggregate") else _latest_pair_history_doc(
+            doc["event_id"], doc["cadet_id"]
+        )
         if latest_doc is not None:
             item.update(_selected_action_state(doc, latest_doc))
 
     return {
         "items": items,
-        "page": page,
-        "page_size": page_size,
-        "total_count": total_count,
-        "total_pages": total_pages,
+        "page": pagination["page"],
+        "page_size": pagination["page_size"],
+        "total_count": pagination["total_count"],
+        "total_pages": pagination["total_pages"],
     }
 
 

--- a/services/commander_attendance.py
+++ b/services/commander_attendance.py
@@ -2,8 +2,13 @@ from __future__ import annotations
 
 from typing import Any
 
+from bson import ObjectId
+
 from services.attendance_merge import merge_attendance_records
+from utils.db import get_collection
+from utils.db_schema_crud import get_attendance_by_event, get_cadets_by_ids, get_users_by_ids
 from utils.names import format_full_name
+from utils.pagination import build_pagination_metadata, paginate_list
 
 
 def build_commander_roster(
@@ -95,3 +100,120 @@ def compute_upserts(
                 }
             )
     return upserts
+
+
+def get_attendance_by_event_for_cadets(
+    event_id: str,
+    cadet_ids: list[Any],
+) -> list[dict[str, Any]]:
+    if not cadet_ids:
+        return []
+
+    col = get_collection("attendance_records")
+    if col is None:
+        return []
+
+    if hasattr(col, "find"):
+        try:
+            return list(
+                col.find(
+                    {
+                        "event_id": ObjectId(event_id),
+                        "cadet_id": {"$in": [ObjectId(cadet_id) for cadet_id in cadet_ids]},
+                    }
+                )
+            )
+        except Exception:
+            pass
+
+    return [
+        record
+        for record in get_attendance_by_event(event_id)
+        if record.get("cadet_id") in cadet_ids
+    ]
+
+
+def _paged_cadet_docs(page: int, page_size: int) -> dict[str, Any]:
+    col = get_collection("cadets")
+    if col is None:
+        return {
+            "items": [],
+            **build_pagination_metadata(page=page, page_size=page_size, total_count=0),
+        }
+
+    if hasattr(col, "count_documents"):
+        total_count = int(col.count_documents({}))
+        pagination = build_pagination_metadata(
+            page=page,
+            page_size=page_size,
+            total_count=total_count,
+        )
+        cursor = col.find({})
+        if hasattr(cursor, "sort"):
+            try:
+                cursor = cursor.sort(
+                    [
+                        ("last_name", 1),
+                        ("first_name", 1),
+                        ("_id", 1),
+                    ]
+                )
+                if pagination["skip"] > 0:
+                    cursor = cursor.skip(pagination["skip"])
+                if pagination["page_size"] > 0:
+                    cursor = cursor.limit(pagination["page_size"])
+                return {**pagination, "items": list(cursor)}
+            except TypeError:
+                pass
+
+    docs = list(col.find({}))
+    docs.sort(
+        key=lambda cadet: (
+            str(cadet.get("last_name", "") or "").lower(),
+            str(cadet.get("first_name", "") or "").lower(),
+            str(cadet.get("_id", "") or ""),
+        )
+    )
+    return paginate_list(docs, page=page, page_size=page_size)
+
+
+def get_paginated_commander_roster(
+    event_id: str,
+    *,
+    page: int,
+    page_size: int,
+) -> dict[str, Any]:
+    cadets_page = _paged_cadet_docs(page, page_size)
+    cadets = list(cadets_page["items"])
+    if not cadets:
+        return {**cadets_page, "items": []}
+
+    cadet_user_ids = [cadet.get("user_id") for cadet in cadets if cadet.get("user_id") is not None]
+    users_by_id = {user["_id"]: user for user in get_users_by_ids(cadet_user_ids)}
+    hydrated_cadets = hydrate_cadet_names(cadets, users_by_id)
+
+    cadet_ids = [cadet.get("_id") for cadet in hydrated_cadets if cadet.get("_id") is not None]
+    records = get_attendance_by_event_for_cadets(event_id, cadet_ids)
+
+    return {**cadets_page, "items": build_commander_roster(hydrated_cadets, records)}
+
+
+def get_roster_entries_for_cadet_ids(
+    event_id: str,
+    cadet_ids: list[str],
+) -> list[dict[str, Any]]:
+    if not cadet_ids:
+        return []
+
+    cadets = get_cadets_by_ids(cadet_ids)
+    if not cadets:
+        return []
+
+    cadet_user_ids = [cadet.get("user_id") for cadet in cadets if cadet.get("user_id") is not None]
+    users_by_id = {user["_id"]: user for user in get_users_by_ids(cadet_user_ids)}
+    hydrated_cadets = hydrate_cadet_names(cadets, users_by_id)
+    records = get_attendance_by_event_for_cadets(
+        event_id,
+        [cadet.get("_id") for cadet in hydrated_cadets if cadet.get("_id") is not None],
+    )
+    return build_commander_roster(hydrated_cadets, records)

--- a/services/waiver_review.py
+++ b/services/waiver_review.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 from datetime import datetime
+import re
+
 from bson import ObjectId
 import pandas as pd
 
+from utils.db import get_collection
 from utils.db_schema_crud import (
     create_waiver_approval,
     get_all_flights,
@@ -16,6 +19,7 @@ from utils.db_schema_crud import (
 )
 
 from utils.names import format_full_name
+from utils.pagination import build_pagination_metadata, paginate_list
 from utils.waiver_email import send_waiver_decision_email
 
 
@@ -45,6 +49,290 @@ def get_waivers(
 
     waivers.sort(key=lambda w: w.get("created_at") or datetime.min, reverse=True)
     return waivers
+
+
+def _waiver_review_match_stage(
+    status_filter: str,
+    viewer_roles: list[str] | None = None,
+) -> dict:
+    match_stage: dict[str, object] = {}
+    if status_filter != "all":
+        match_stage["status"] = status_filter
+
+    roles = set(viewer_roles or [])
+    if not (roles & {"admin", "cadre"}):
+        match_stage["cadre_only"] = {"$ne": True}
+
+    return match_stage
+
+
+def _waiver_review_base_pipeline(
+    *,
+    status_filter: str,
+    flight_filter: str,
+    cadet_search: str,
+    viewer_roles: list[str] | None,
+) -> list[dict]:
+    search_regex = re.escape(cadet_search.strip()) if cadet_search.strip() else ""
+    pipeline: list[dict] = []
+    match_stage = _waiver_review_match_stage(status_filter, viewer_roles)
+    if match_stage:
+        pipeline.append({"$match": match_stage})
+
+    pipeline.extend(
+        [
+            {
+                "$lookup": {
+                    "from": "attendance_records",
+                    "localField": "attendance_record_id",
+                    "foreignField": "_id",
+                    "as": "attendance_record",
+                }
+            },
+            {"$unwind": "$attendance_record"},
+            {
+                "$lookup": {
+                    "from": "cadets",
+                    "localField": "attendance_record.cadet_id",
+                    "foreignField": "_id",
+                    "as": "cadet",
+                }
+            },
+            {"$unwind": "$cadet"},
+            {
+                "$lookup": {
+                    "from": "users",
+                    "localField": "cadet.user_id",
+                    "foreignField": "_id",
+                    "as": "cadet_user",
+                }
+            },
+            {
+                "$unwind": {
+                    "path": "$cadet_user",
+                    "preserveNullAndEmptyArrays": True,
+                }
+            },
+            {
+                "$lookup": {
+                    "from": "flights",
+                    "localField": "cadet.flight_id",
+                    "foreignField": "_id",
+                    "as": "flight",
+                }
+            },
+            {
+                "$unwind": {
+                    "path": "$flight",
+                    "preserveNullAndEmptyArrays": True,
+                }
+            },
+            {
+                "$lookup": {
+                    "from": "events",
+                    "localField": "attendance_record.event_id",
+                    "foreignField": "_id",
+                    "as": "event",
+                }
+            },
+            {
+                "$unwind": {
+                    "path": "$event",
+                    "preserveNullAndEmptyArrays": True,
+                }
+            },
+            {
+                "$addFields": {
+                    "cadet_name_search": {
+                        "$trim": {
+                            "input": {
+                                "$concat": [
+                                    {"$ifNull": ["$cadet_user.first_name", "$cadet.first_name"]},
+                                    " ",
+                                    {"$ifNull": ["$cadet_user.last_name", "$cadet.last_name"]},
+                                ]
+                            }
+                        }
+                    },
+                    "cadet_email_search": {
+                        "$ifNull": ["$cadet_user.email", "$cadet.email"]
+                    },
+                }
+            },
+        ]
+    )
+
+    if flight_filter != "All flights":
+        pipeline.append({"$match": {"flight.name": flight_filter}})
+
+    if search_regex:
+        pipeline.append(
+            {
+                "$match": {
+                    "$or": [
+                        {"cadet_name_search": {"$regex": search_regex, "$options": "i"}},
+                        {"cadet_email_search": {"$regex": search_regex, "$options": "i"}},
+                    ]
+                }
+            }
+        )
+
+    return pipeline
+
+
+def _waiver_review_rows_from_docs(docs: list[dict]) -> list[dict]:
+    rows: list[dict] = []
+    for doc in docs:
+        cadet_user = doc.get("cadet_user") or {}
+        cadet = doc.get("cadet") or {}
+        event = doc.get("event") or {}
+        flight = doc.get("flight") or {}
+
+        cadet_name = format_full_name(cadet_user)
+        if not cadet_name:
+            first = str(cadet.get("first_name", "") or "").strip()
+            last = str(cadet.get("last_name", "") or "").strip()
+            cadet_name = f"{first} {last}".strip() or "Unknown cadet"
+
+        rows.append(
+            {
+                "waiver_id": doc.get("_id"),
+                "waiver_status": str(doc.get("status") or "pending").lower(),
+                "waiver_type": doc.get("waiver_type") or "non-medical",
+                "attachments": doc.get("attachments") or [],
+                "reason": doc.get("reason", ""),
+                "cadet_name": cadet_name,
+                "cadet_email": str(cadet_user.get("email") or cadet.get("email") or ""),
+                "flight_name": str(flight.get("name") or "Unassigned"),
+                "event_name": str(event.get("event_name") or "Unknown event"),
+                "event_date": _fmt_date(event.get("start_date")),
+                "event_type": (event.get("event_type") or "") or "unknown",
+                "cadre_only": bool(doc.get("cadre_only", False)),
+            }
+        )
+    return rows
+
+
+def _fallback_waiver_review_rows(
+    *,
+    status_filter: str,
+    flight_filter: str,
+    cadet_search: str,
+    viewer_roles: list[str] | None,
+) -> list[dict]:
+    rows: list[dict] = []
+    search_value = cadet_search.strip().lower()
+
+    for waiver in get_waivers(status_filter, viewer_roles):
+        waiver_id = waiver.get("_id")
+        if waiver_id is None:
+            continue
+
+        ctx = get_waiver_context(waiver)
+        if ctx is None:
+            continue
+
+        if flight_filter != "All flights" and ctx["flight_name"] != flight_filter:
+            continue
+
+        if search_value:
+            haystack = f"{ctx['cadet_name']} {ctx['cadet_email']}".lower()
+            if search_value not in haystack:
+                continue
+
+        rows.append(
+            {
+                "waiver_id": waiver_id,
+                "waiver_status": (waiver.get("status") or "pending").lower(),
+                "waiver_type": ctx["waiver_type"],
+                "attachments": ctx["attachments"],
+                "reason": waiver.get("reason", ""),
+                "cadet_name": ctx["cadet_name"],
+                "cadet_email": ctx["cadet_email"],
+                "flight_name": ctx["flight_name"],
+                "event_name": ctx["event_name"],
+                "event_date": ctx["event_date"],
+                "event_type": ctx["event_type"],
+                "cadre_only": ctx["cadre_only"],
+            }
+        )
+
+    return rows
+
+
+def get_waiver_review_rows(
+    *,
+    status_filter: str,
+    flight_filter: str,
+    cadet_search: str,
+    viewer_roles: list[str] | None = None,
+) -> list[dict]:
+    col = get_collection("waivers")
+    if col is None or not hasattr(col, "aggregate"):
+        return _fallback_waiver_review_rows(
+            status_filter=status_filter,
+            flight_filter=flight_filter,
+            cadet_search=cadet_search,
+            viewer_roles=viewer_roles,
+        )
+
+    pipeline = _waiver_review_base_pipeline(
+        status_filter=status_filter,
+        flight_filter=flight_filter,
+        cadet_search=cadet_search,
+        viewer_roles=viewer_roles,
+    )
+    docs = list(col.aggregate(pipeline + [{"$sort": {"created_at": -1, "_id": -1}}]))
+    return _waiver_review_rows_from_docs(docs)
+
+
+def get_paginated_waiver_review_rows(
+    *,
+    status_filter: str,
+    flight_filter: str,
+    cadet_search: str,
+    viewer_roles: list[str] | None = None,
+    page: int = 1,
+    page_size: int = 25,
+) -> dict[str, object]:
+    col = get_collection("waivers")
+    if col is None or not hasattr(col, "aggregate"):
+        paginated = paginate_list(
+            get_waiver_review_rows(
+                status_filter=status_filter,
+                flight_filter=flight_filter,
+                cadet_search=cadet_search,
+                viewer_roles=viewer_roles,
+            ),
+            page=page,
+            page_size=page_size,
+        )
+        return paginated
+
+    base_pipeline = _waiver_review_base_pipeline(
+        status_filter=status_filter,
+        flight_filter=flight_filter,
+        cadet_search=cadet_search,
+        viewer_roles=viewer_roles,
+    )
+    count_docs = list(col.aggregate(base_pipeline + [{"$count": "total_count"}]))
+    total_count = int(count_docs[0]["total_count"]) if count_docs else 0
+    pagination = build_pagination_metadata(
+        page=page,
+        page_size=page_size,
+        total_count=total_count,
+    )
+    docs = list(
+        col.aggregate(
+            base_pipeline
+            + [
+                {"$sort": {"created_at": -1, "_id": -1}},
+                {"$skip": pagination["skip"]},
+                {"$limit": pagination["page_size"]},
+            ]
+        )
+    )
+    return {**pagination, "items": _waiver_review_rows_from_docs(docs)}
 
 
 def get_waiver_context(waiver: dict) -> dict | None:

--- a/tests/test_commander_attendance.py
+++ b/tests/test_commander_attendance.py
@@ -1,4 +1,10 @@
-from services.commander_attendance import build_commander_roster, compute_upserts
+import services.commander_attendance as commander_attendance
+from services.commander_attendance import (
+    build_commander_roster,
+    compute_upserts,
+    get_paginated_commander_roster,
+    get_roster_entries_for_cadet_ids,
+)
 
 
 # ── build_commander_roster ────────────────────────────────────────────────────
@@ -167,3 +173,77 @@ def test_upsert_all_three_statuses():
 
 def test_upsert_empty_roster_returns_empty():
     assert compute_upserts([], {}) == []
+
+
+def test_get_paginated_commander_roster_hydrates_only_current_page(monkeypatch):
+    monkeypatch.setattr(
+        commander_attendance,
+        "_paged_cadet_docs",
+        lambda page, page_size: {
+            "items": [
+                {"_id": "c2", "user_id": "u2", "first_name": "Bob", "last_name": "B"},
+                {"_id": "c3", "user_id": "u3", "first_name": "Cara", "last_name": "C"},
+            ],
+            "page": 2,
+            "page_size": 25,
+            "total_count": 3,
+            "total_pages": 2,
+            "skip": 25,
+        },
+    )
+    monkeypatch.setattr(
+        commander_attendance,
+        "get_users_by_ids",
+        lambda ids: [
+            {"_id": "u2", "first_name": "Bob", "last_name": "Baker"},
+            {"_id": "u3", "first_name": "Cara", "last_name": "Cole"},
+        ],
+    )
+    monkeypatch.setattr(
+        commander_attendance,
+        "get_attendance_by_event_for_cadets",
+        lambda event_id, cadet_ids: [
+            {"cadet_id": "c2", "_id": "r2", "status": "present"},
+        ],
+    )
+
+    roster = get_paginated_commander_roster("evt1", page=2, page_size=25)
+
+    assert roster["page"] == 2
+    assert roster["total_count"] == 3
+    assert [entry["cadet"]["_id"] for entry in roster["items"]] == ["c2", "c3"]
+    assert roster["items"][0]["cadet"]["name"] == "Bob Baker"
+    assert roster["items"][0]["current_status"] == "present"
+    assert roster["items"][1]["current_status"] is None
+
+
+def test_get_roster_entries_for_cadet_ids_loads_only_requested_cadets(monkeypatch):
+    monkeypatch.setattr(
+        commander_attendance,
+        "get_cadets_by_ids",
+        lambda cadet_ids: [
+            {"_id": "c1", "user_id": "u1", "first_name": "Amy", "last_name": "A"},
+            {"_id": "c3", "user_id": "u3", "first_name": "Cara", "last_name": "C"},
+        ],
+    )
+    monkeypatch.setattr(
+        commander_attendance,
+        "get_users_by_ids",
+        lambda ids: [
+            {"_id": "u1", "first_name": "Amy", "last_name": "Avery"},
+            {"_id": "u3", "first_name": "Cara", "last_name": "Cole"},
+        ],
+    )
+    monkeypatch.setattr(
+        commander_attendance,
+        "get_attendance_by_event_for_cadets",
+        lambda event_id, cadet_ids: [
+            {"cadet_id": "c3", "_id": "r3", "status": "absent"},
+        ],
+    )
+
+    roster = get_roster_entries_for_cadet_ids("evt1", ["c1", "c3"])
+
+    assert [entry["cadet"]["_id"] for entry in roster] == ["c1", "c3"]
+    assert roster[0]["current_status"] is None
+    assert roster[1]["current_status"] == "absent"

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,0 +1,28 @@
+from utils.pagination import build_pagination_metadata, normalize_page_size, paginate_list
+
+
+def test_normalize_page_size_rejects_unsupported_values():
+    assert normalize_page_size(10) == 25
+    assert normalize_page_size("50") == 50
+
+
+def test_build_pagination_metadata_clamps_page_to_last_page():
+    pagination = build_pagination_metadata(page=99, page_size=25, total_count=40)
+
+    assert pagination["page"] == 2
+    assert pagination["page_size"] == 25
+    assert pagination["total_pages"] == 2
+    assert pagination["skip"] == 25
+
+
+def test_paginate_list_returns_slice_and_metadata():
+    paginated = paginate_list(
+        [{"value": value} for value in range(6)],
+        page=2,
+        page_size=25,
+    )
+
+    assert paginated["page"] == 1
+    assert paginated["page_size"] == 25
+    assert paginated["total_count"] == 6
+    assert [item["value"] for item in paginated["items"]] == list(range(6))

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,9 +1,31 @@
+import pytest
+
 from utils.pagination import build_pagination_metadata, normalize_page_size, paginate_list
 
 
-def test_normalize_page_size_rejects_unsupported_values():
-    assert normalize_page_size(10) == 25
-    assert normalize_page_size("50") == 50
+@pytest.mark.parametrize("page_size", [25, "50", 100])
+def test_normalize_page_size_accepts_valid_values(page_size):
+    assert normalize_page_size(page_size) == int(page_size)
+
+
+@pytest.mark.parametrize("page_size", [10, "abc", None, 0, -25])
+def test_normalize_page_size_defaults_invalid_values(page_size):
+    assert normalize_page_size(page_size) == 25
+
+
+@pytest.mark.parametrize("page", [0, -1])
+def test_build_pagination_metadata_clamps_non_positive_page_to_first_page(page):
+    pagination = build_pagination_metadata(page=page, page_size=25, total_count=40)
+
+    assert pagination["page"] == 1
+    assert pagination["skip"] == 0
+
+
+def test_build_pagination_metadata_defaults_non_numeric_page_size():
+    pagination = build_pagination_metadata(page=1, page_size="abc", total_count=40)
+
+    assert pagination["page_size"] == 25
+    assert pagination["total_pages"] == 2
 
 
 def test_build_pagination_metadata_clamps_page_to_last_page():
@@ -15,14 +37,37 @@ def test_build_pagination_metadata_clamps_page_to_last_page():
     assert pagination["skip"] == 25
 
 
-def test_paginate_list_returns_slice_and_metadata():
+def test_build_pagination_metadata_returns_normal_page_without_clamping():
+    pagination = build_pagination_metadata(page=2, page_size=25, total_count=90)
+
+    assert pagination["page"] == 2
+    assert pagination["page_size"] == 25
+    assert pagination["total_count"] == 90
+    assert pagination["total_pages"] == 4
+    assert pagination["skip"] == 25
+
+
+def test_paginate_list_returns_empty_collection_metadata():
+    paginated = paginate_list([], page=2, page_size=25)
+
+    assert paginated["page"] == 1
+    assert paginated["page_size"] == 25
+    assert paginated["total_count"] == 0
+    assert paginated["total_pages"] == 1
+    assert paginated["skip"] == 0
+    assert paginated["items"] == []
+
+
+def test_paginate_list_returns_multi_page_slice_and_metadata():
     paginated = paginate_list(
-        [{"value": value} for value in range(6)],
+        [{"value": value} for value in range(60)],
         page=2,
         page_size=25,
     )
 
-    assert paginated["page"] == 1
+    assert paginated["page"] == 2
     assert paginated["page_size"] == 25
-    assert paginated["total_count"] == 6
-    assert [item["value"] for item in paginated["items"]] == list(range(6))
+    assert paginated["total_count"] == 60
+    assert paginated["total_pages"] == 3
+    assert paginated["skip"] == 25
+    assert [item["value"] for item in paginated["items"]] == list(range(25, 50))

--- a/tests/test_waiver_review.py
+++ b/tests/test_waiver_review.py
@@ -5,8 +5,10 @@ import pandas as pd
 
 from services.waiver_review import (
     get_flight_options,
+    get_paginated_waiver_review_rows,
     get_waiver_context,
     get_waiver_export_df,
+    get_waiver_review_rows,
     get_waivers,
     submit_decision,
 )
@@ -98,6 +100,88 @@ def test_get_waivers_empty():
     with patch("services.waiver_review.get_all_waivers", return_value=[]):
         result = get_waivers("all")
         assert result == []
+
+
+def test_get_waiver_review_rows_filters_fallback_data():
+    waivers = [WAIVER, {**WAIVER, "_id": "w2", "status": "approved"}]
+    with (
+        patch("services.waiver_review.get_collection", return_value=None),
+        patch("services.waiver_review.get_waivers", return_value=waivers),
+        patch(
+            "services.waiver_review.get_waiver_context",
+            side_effect=[
+                {
+                    "cadet_name": "Tyler Brooks",
+                    "cadet_email": "tyler@rollcall.local",
+                    "flight_name": "Alpha Flight",
+                    "event_name": "PT Session",
+                    "event_date": "2026-03-01",
+                    "event_type": "pt",
+                    "waiver_type": "medical",
+                    "attachments": [],
+                    "cadre_only": False,
+                },
+                {
+                    "cadet_name": "Morgan Lake",
+                    "cadet_email": "morgan@rollcall.local",
+                    "flight_name": "Bravo Flight",
+                    "event_name": "LLAB",
+                    "event_date": "2026-03-02",
+                    "event_type": "lab",
+                    "waiver_type": "non-medical",
+                    "attachments": [],
+                    "cadre_only": False,
+                },
+            ],
+        ),
+    ):
+        result = get_waiver_review_rows(
+            status_filter="all",
+            flight_filter="Alpha Flight",
+            cadet_search="tyler",
+            viewer_roles=["cadre"],
+        )
+
+    assert len(result) == 1
+    assert result[0]["waiver_id"] == "w1"
+    assert result[0]["flight_name"] == "Alpha Flight"
+
+
+def test_get_paginated_waiver_review_rows_paginates_fallback_rows():
+    rows = [
+        {
+            "waiver_id": f"w{index}",
+            "waiver_status": "pending",
+            "waiver_type": "medical",
+            "attachments": [],
+            "reason": "Reason",
+            "cadet_name": f"Cadet {index}",
+            "cadet_email": f"cadet{index}@rollcall.local",
+            "flight_name": "Alpha Flight",
+            "event_name": "PT",
+            "event_date": "2026-03-01",
+            "event_type": "pt",
+            "cadre_only": False,
+        }
+        for index in range(30)
+    ]
+    with (
+        patch("services.waiver_review.get_collection", return_value=None),
+        patch("services.waiver_review.get_waiver_review_rows", return_value=rows),
+    ):
+        result = get_paginated_waiver_review_rows(
+            status_filter="all",
+            flight_filter="All flights",
+            cadet_search="",
+            viewer_roles=["cadre"],
+            page=2,
+            page_size=25,
+        )
+
+    assert result["page"] == 2
+    assert result["total_count"] == 30
+    assert result["total_pages"] == 2
+    assert len(result["items"]) == 5
 
 
 # ------------------------- test get_waiver_context -----------------------------------------

--- a/utils/pagination.py
+++ b/utils/pagination.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from math import ceil
+from typing import Any, Mapping
+
+import streamlit as st
+
+PAGE_SIZE_OPTIONS: tuple[int, ...] = (25, 50, 100)
+DEFAULT_PAGE_SIZE = PAGE_SIZE_OPTIONS[0]
+
+
+def _coerce_page_size(value: Any, *, default: int = DEFAULT_PAGE_SIZE) -> int:
+    try:
+        page_size = int(value)
+    except (TypeError, ValueError):
+        return default
+    return page_size if page_size > 0 else default
+
+
+def normalize_page(value: Any) -> int:
+    try:
+        page = int(value)
+    except (TypeError, ValueError):
+        return 1
+    return max(page, 1)
+
+
+def normalize_page_size(
+    value: Any,
+    *,
+    allowed: tuple[int, ...] = PAGE_SIZE_OPTIONS,
+    default: int = DEFAULT_PAGE_SIZE,
+) -> int:
+    try:
+        page_size = int(value)
+    except (TypeError, ValueError):
+        return default
+    return page_size if page_size in allowed else default
+
+
+def build_pagination_metadata(
+    *,
+    page: Any,
+    page_size: Any,
+    total_count: Any,
+) -> dict[str, int]:
+    normalized_page_size = _coerce_page_size(page_size)
+    normalized_total_count = max(int(total_count or 0), 0)
+    total_pages = max(1, ceil(normalized_total_count / normalized_page_size))
+    normalized_page = min(normalize_page(page), total_pages)
+    skip = (normalized_page - 1) * normalized_page_size
+
+    return {
+        "page": normalized_page,
+        "page_size": normalized_page_size,
+        "total_count": normalized_total_count,
+        "total_pages": total_pages,
+        "skip": skip,
+    }
+
+
+def paginate_list(
+    items: list[dict[str, Any]],
+    *,
+    page: Any,
+    page_size: Any,
+) -> dict[str, Any]:
+    pagination = build_pagination_metadata(
+        page=page,
+        page_size=page_size,
+        total_count=len(items),
+    )
+    start = pagination["skip"]
+    end = start + pagination["page_size"]
+    return {**pagination, "items": items[start:end]}
+
+
+def init_pagination_state(
+    prefix: str,
+    *,
+    reset_token: str | None = None,
+    default_page_size: int = DEFAULT_PAGE_SIZE,
+) -> tuple[int, int]:
+    page_key = f"{prefix}_page"
+    page_size_key = f"{prefix}_page_size"
+    reset_key = f"{prefix}_reset_token"
+
+    if page_size_key not in st.session_state:
+        st.session_state[page_size_key] = normalize_page_size(default_page_size)
+    else:
+        st.session_state[page_size_key] = normalize_page_size(
+            st.session_state[page_size_key]
+        )
+
+    if page_key not in st.session_state:
+        st.session_state[page_key] = 1
+    else:
+        st.session_state[page_key] = normalize_page(st.session_state[page_key])
+
+    if reset_token is not None and st.session_state.get(reset_key) != reset_token:
+        st.session_state[reset_key] = reset_token
+        st.session_state[page_key] = 1
+
+    return st.session_state[page_key], st.session_state[page_size_key]
+
+
+def sync_pagination_state(prefix: str, pagination: Mapping[str, Any]) -> None:
+    st.session_state[f"{prefix}_page"] = int(pagination.get("page", 1) or 1)
+    st.session_state[f"{prefix}_page_size"] = normalize_page_size(
+        pagination.get("page_size", DEFAULT_PAGE_SIZE)
+    )
+
+
+def render_pagination_controls(
+    prefix: str,
+    pagination: Mapping[str, Any],
+    *,
+    rerun_scope: str | None = None,
+) -> None:
+    page_key = f"{prefix}_page"
+    page_size_key = f"{prefix}_page_size"
+    page_value = int(pagination.get("page", 1) or 1)
+    page_size_value = normalize_page_size(pagination.get("page_size", DEFAULT_PAGE_SIZE))
+    total_pages = max(int(pagination.get("total_pages", 1) or 1), 1)
+    total_count = max(int(pagination.get("total_count", 0) or 0), 0)
+
+    def _reset_to_first_page() -> None:
+        st.session_state[page_key] = 1
+
+    summary_col, page_col, page_size_col, prev_col, next_col = st.columns([3, 1, 1, 1, 1])
+    summary_col.caption(f"Page {page_value} of {total_pages} • {total_count} total")
+    page_col.selectbox(
+        "Page",
+        options=list(range(1, total_pages + 1)),
+        key=page_key,
+        label_visibility="collapsed",
+    )
+    page_size_col.selectbox(
+        "Page size",
+        options=list(PAGE_SIZE_OPTIONS),
+        key=page_size_key,
+        label_visibility="collapsed",
+        on_change=_reset_to_first_page,
+    )
+
+    rerun_kwargs = {}
+    if rerun_scope is not None:
+        rerun_kwargs["scope"] = rerun_scope
+
+    if prev_col.button(
+        "Previous",
+        key=f"{prefix}_prev",
+        disabled=page_value <= 1,
+        width="stretch",
+    ):
+        st.session_state[page_key] = page_value - 1
+        st.rerun(**rerun_kwargs)
+
+    if next_col.button(
+        "Next",
+        key=f"{prefix}_next",
+        disabled=page_value >= total_pages,
+        width="stretch",
+    ):
+        st.session_state[page_key] = page_value + 1
+        st.rerun(**rerun_kwargs)

--- a/utils/pagination.py
+++ b/utils/pagination.py
@@ -127,6 +127,9 @@ def render_pagination_controls(
     def _reset_to_first_page() -> None:
         st.session_state[page_key] = 1
 
+    def _go_to_page(next_page: int) -> None:
+        st.session_state[page_key] = min(max(int(next_page), 1), total_pages)
+
     summary_col, page_col, page_size_col, prev_col, next_col = st.columns([3, 1, 1, 1, 1])
     summary_col.caption(f"Page {page_value} of {total_pages} • {total_count} total")
     page_col.selectbox(
@@ -143,24 +146,20 @@ def render_pagination_controls(
         on_change=_reset_to_first_page,
     )
 
-    rerun_kwargs = {}
-    if rerun_scope is not None:
-        rerun_kwargs["scope"] = rerun_scope
-
-    if prev_col.button(
+    prev_col.button(
         "Previous",
         key=f"{prefix}_prev",
         disabled=page_value <= 1,
         width="stretch",
-    ):
-        st.session_state[page_key] = page_value - 1
-        st.rerun(**rerun_kwargs)
+        on_click=_go_to_page,
+        args=(page_value - 1,),
+    )
 
-    if next_col.button(
+    next_col.button(
         "Next",
         key=f"{prefix}_next",
         disabled=page_value >= total_pages,
         width="stretch",
-    ):
-        st.session_state[page_key] = page_value + 1
-        st.rerun(**rerun_kwargs)
+        on_click=_go_to_page,
+        args=(page_value + 1,),
+    )


### PR DESCRIPTION
This PR adds a shared pagination system to the largest attendance and admin views. waiver review now uses server side filtering and pagination, attendance modification now paginates both the attendance roster and recent change history table. Dashboard, cadet management, and user management pages now paginate their large tables using the same shared pagination utils. adds tests for the new pagination behavior.


closes #234 