### PR TITLE
Add event editing support (#219)

### DIFF
--- a/pages/6_Event_Management_CRUD.py
+++ b/pages/6_Event_Management_CRUD.py
@@ -6,7 +6,7 @@ from services.event_config import (
     _DEFAULT_PT_THRESHOLD,
     _DEFAULT_LLAB_THRESHOLD,
 )
-from services.events import create_event, delete_event, get_all_events, get_timezone_options
+from services.events import create_event, delete_event, get_all_events, get_timezone_options, update_event
 from utils.auth import require_role, get_current_user
 
 require_role("admin", "cadre")
@@ -17,6 +17,10 @@ if "create_event_success" not in st.session_state:
     st.session_state.create_event_success = None
 if "delete_event_success" not in st.session_state:
     st.session_state.delete_event_success = None
+if "edit_event_id" not in st.session_state:
+    st.session_state.edit_event_id = None
+if "edit_event_success" not in st.session_state:
+    st.session_state.edit_event_success = None
 
 st.title("Event Management")
 
@@ -34,7 +38,7 @@ DAYS_OF_WEEK = [
 
 
 def infer_event_type(selected_date: date, config: dict) -> str:
-    """Return PT, LLAB, or empty string based on the saved schedule config."""
+    """Return pt or lab based on the saved schedule config."""
     day_name = selected_date.strftime("%A")
     if day_name in config.get("pt_days", []):
         return "pt"
@@ -88,7 +92,7 @@ with st.expander("Event Schedule Configuration", expanded=False):
     if st.button("Save Schedule Configuration"):
         if save_event_config(pt_days, llab_days, pt_threshold, llab_threshold):
             st.success("Schedule configuration saved!")
-            config = get_event_config() or {}  # refresh so create form picks it up
+            config = get_event_config() or {}
             st.rerun()
         else:
             st.error("Database unavailable — could not save configuration.")
@@ -113,7 +117,6 @@ with st.form("create_event_form"):
         "Dates are stored as 12:00 AM through 11:59 PM in the selected timezone."
     )
 
-    # Auto-populate type from schedule config based on start date
     auto_type = infer_event_type(start_date, config)
     type_options = ["pt", "lab"]
     default_index = type_options.index(auto_type) if auto_type in type_options else 0
@@ -156,11 +159,14 @@ if st.session_state.create_event_success:
 if st.session_state.delete_event_success:
     st.success(st.session_state.delete_event_success)
     st.session_state.delete_event_success = None
+if st.session_state.edit_event_success:
+    st.success(st.session_state.edit_event_success)
+    st.session_state.edit_event_success = None
 
 st.divider()
 
 # =============================================================================
-# SECTION 3 — Existing Events (table view + delete)
+# SECTION 3 — Existing Events (table view + edit + delete)
 # =============================================================================
 
 st.subheader("Existing Events")
@@ -171,7 +177,6 @@ events = get_all_events()
 if not events:
     st.info("No events found. Create one above.")
 else:
-    # Build display table
     import pandas as pd
 
     df = pd.DataFrame(
@@ -188,8 +193,81 @@ else:
 
     st.dataframe(df, width="stretch", hide_index=True)
 
-    # Delete section below the table
-    st.markdown("**Delete an Event**")
+    # ── Edit section ─────────────────────────────────────────────────────────
+    st.subheader("Edit an Event")
+    edit_labels = [
+        f"{e.get('start_date', '—')} — {e.get('event_name', '—')}" for e in events
+    ]
+    selected_edit_label = st.selectbox("Select event to edit", edit_labels, key="edit_selectbox")
+    selected_edit_event = events[edit_labels.index(selected_edit_label)]
+
+    if st.button("Edit Selected Event"):
+        st.session_state.edit_event_id = selected_edit_event["_id"]
+        st.rerun()
+
+    if st.session_state.edit_event_id == selected_edit_event["_id"]:
+        with st.form("edit_event_form"):
+            st.markdown(f"**Editing:** {selected_edit_event.get('event_name', '')}")
+
+            new_name = st.text_input(
+                "Event Name",
+                value=selected_edit_event.get("event_name", ""),
+            )
+
+            existing_start = selected_edit_event.get("start_date", "")
+            existing_end = selected_edit_event.get("end_date", "")
+            try:
+                parsed_start = date.fromisoformat(str(existing_start)[:10])
+            except ValueError:
+                parsed_start = date.today()
+            try:
+                parsed_end = date.fromisoformat(str(existing_end)[:10])
+            except ValueError:
+                parsed_end = date.today()
+
+            new_start = st.date_input("Start Date", value=parsed_start, key="edit_start")
+            new_end = st.date_input("End Date", value=parsed_end, key="edit_end")
+
+            existing_tz = selected_edit_event.get("timezone_name", "UTC")
+            tz_index = TZ_OPTIONS.index(existing_tz) if existing_tz in TZ_OPTIONS else 0
+            new_tz = st.selectbox("Timezone", TZ_OPTIONS, index=tz_index, key="edit_tz")
+
+            existing_type = selected_edit_event.get("event_type", "pt")
+            type_options = ["pt", "lab"]
+            type_index = type_options.index(existing_type) if existing_type in type_options else 0
+            new_type = st.selectbox("Event Type", type_options, index=type_index, key="edit_type")
+
+            c1, c2 = st.columns(2)
+            save = c1.form_submit_button("Save Changes", type="primary")
+            cancel = c2.form_submit_button("Cancel")
+
+        if save:
+            if not new_name.strip():
+                st.error("Event name cannot be empty.")
+            elif new_end < new_start:
+                st.error("End date cannot be before start date.")
+            else:
+                if update_event(
+                    selected_edit_event["_id"],
+                    new_name.strip(),
+                    new_type,
+                    new_start,
+                    new_end,
+                    new_tz,
+                ):
+                    st.session_state.edit_event_id = None
+                    st.session_state.edit_event_success = f"Event '{new_name.strip()}' updated successfully!"
+                    st.rerun()
+                else:
+                    st.error("Could not update event.")
+        if cancel:
+            st.session_state.edit_event_id = None
+            st.rerun()
+
+    st.divider()
+
+    # ── Delete section ────────────────────────────────────────────────────────
+    st.subheader("Delete an Event")
     event_labels = [
         f"{e.get('start_date', '—')} — {e.get('event_name', '—')}" for e in events
     ]

--- a/services/events.py
+++ b/services/events.py
@@ -156,3 +156,33 @@ def delete_event(event_id: str) -> bool:
         return False
     result = db.events.delete_one({"_id": ObjectId(event_id)})
     return result.deleted_count == 1
+
+
+def update_event(
+    event_id: str,
+    name: str,
+    event_type: str,
+    start_date: date,
+    end_date: date,
+    tz_name: str = "UTC",
+) -> bool:
+    """Update an existing event. Returns True on success."""
+    if start_date > end_date:
+        return False
+    db = get_db()
+    if db is None:
+        return False
+    start_dt, end_dt = build_event_bounds(start_date, end_date, tz_name)
+    result = db.events.update_one(
+        {"_id": ObjectId(event_id)},
+        {
+            "$set": {
+                "event_name": name,
+                "event_type": event_type,
+                "start_date": start_dt,
+                "end_date": end_dt,
+                "timezone_name": tz_name,
+            }
+        },
+    )
+    return result.modified_count == 1


### PR DESCRIPTION
Closes #219

- Added `update_event()` to `services/events.py`
- Added inline edit form to Event Management page
- Pre-fills existing event name, type, dates and timezone
- Save/Cancel buttons with confirmation message on success
- Delete and create flows unchanged