### PR TITLE
email temp passwords on roster import and enforce first-login password change

### DIFF
--- a/Home.py
+++ b/Home.py
@@ -111,10 +111,23 @@ else:
     else:
         pages = []
 
-    pages.append(account_settings)
+    if user.get("force_password_change"):
+        st.warning(
+            "You must change your temporary password before continuing.",
+        )
+        pages = [account_settings]
+    else:
+        pages.append(account_settings)
 
     if not pages:
         pages = [login]
+
+    redirect_after_password_reset = st.session_state.pop(
+        "post_password_reset_redirect", None
+    )
+    if redirect_after_password_reset == "attendance_submission":
+        target_page = attendance if attendance in pages else pages[0]
+        st.switch_page(target_page)
 
     pg = st.navigation(pages)
 

--- a/pages/13_Email_Templates.py
+++ b/pages/13_Email_Templates.py
@@ -14,6 +14,7 @@ TEMPLATE_LABELS = {
     "at_risk_cadre": "At-Risk Report (cadre/FC)",
     "at_risk_student": "At-Risk Alert (cadet)",
     "test_email": "Test Email",
+    "roster_temp_password": "Temporary Password",
 }
 
 TEMPLATE_VARIABLES = {
@@ -22,6 +23,7 @@ TEMPLATE_VARIABLES = {
     "at_risk_cadre": "{recipient_name}, {pt_threshold}, {llab_threshold}, {table}",
     "at_risk_student": "{message}",
     "test_email": "no variables",
+    "roster_temp_password": "{temporary_password}",
 }
 
 

--- a/pages/2_Attendance_Submission.py
+++ b/pages/2_Attendance_Submission.py
@@ -70,6 +70,13 @@ st.markdown(
     unsafe_allow_html=True,
 )
 _location = get_geolocation(component_key="geo_checkin")
+_coords = _location.get("coords") if isinstance(_location, dict) else None
+_has_coords = isinstance(_coords, dict)
+
+if _has_coords:
+    st.caption("Location detected")
+else:
+    st.caption("Location unavailable")
 
 
 st.subheader("Enter your 6-digit event code")
@@ -139,9 +146,10 @@ if len(code_clean) == 6:
 
                     # Geofence check
                     if event.get("geofence_enabled"):
-                        if _location:
-                            cadet_lat = _location["coords"]["latitude"]
-                            cadet_lon = _location["coords"]["longitude"]
+                        if _has_coords:
+                            cadet_lat = _coords.get("latitude")
+                            cadet_lon = _coords.get("longitude")
+                        if cadet_lat is not None and cadet_lon is not None:
                             within, warning = is_within_geofence(
                                 event, cadet_lat, cadet_lon
                             )
@@ -158,40 +166,43 @@ if len(code_clean) == 6:
 
 # ── Location map — shown whenever GPS has resolved ────────────────────────────
 
-if _location:
-    _lat = _location["coords"]["latitude"]
-    _lon = _location["coords"]["longitude"]
-    _m = folium.Map(location=[_lat, _lon], zoom_start=17)
-    folium.Marker(
-        [_lat, _lon],
-        tooltip="Your location",
-        icon=folium.Icon(color="blue", icon="user", prefix="fa"),
-    ).add_to(_m)
+if _has_coords:
+    _lat = _coords.get("latitude")
+    _lon = _coords.get("longitude")
+    if _lat is not None and _lon is not None:
+        _m = folium.Map(location=[_lat, _lon], zoom_start=17)
+        folium.Marker(
+            [_lat, _lon],
+            tooltip="Your location",
+            icon=folium.Icon(color="blue", icon="user", prefix="fa"),
+        ).add_to(_m)
 
-    # Overlay geofence if a validated geofence event is in scope
-    if _validated_event and _validated_event.get("geofence_enabled"):
-        fence_lat = _validated_event.get("geofence_lat")
-        fence_lon = _validated_event.get("geofence_lon")
-        radius = _validated_event.get("geofence_radius_meters", 150)
-        if fence_lat is not None and fence_lon is not None:
-            within, _ = is_within_geofence(_validated_event, _lat, _lon)
-            folium.Circle(
-                location=[fence_lat, fence_lon],
-                radius=radius,
-                color="#00aa44" if within else "#cc0000",
-                fill=True,
-                fill_opacity=0.15,
-                tooltip="Geofence boundary",
-            ).add_to(_m)
-            folium.Marker(
-                [fence_lat, fence_lon],
-                tooltip="Formation location",
-                icon=folium.Icon(
-                    color="green" if within else "red", icon="flag", prefix="fa"
-                ),
-            ).add_to(_m)
+        # Overlay geofence if a validated geofence event is in scope
+        if _validated_event and _validated_event.get("geofence_enabled"):
+            fence_lat = _validated_event.get("geofence_lat")
+            fence_lon = _validated_event.get("geofence_lon")
+            radius = _validated_event.get("geofence_radius_meters", 150)
+            if fence_lat is not None and fence_lon is not None:
+                within, _ = is_within_geofence(_validated_event, _lat, _lon)
+                folium.Circle(
+                    location=[fence_lat, fence_lon],
+                    radius=radius,
+                    color="#00aa44" if within else "#cc0000",
+                    fill=True,
+                    fill_opacity=0.15,
+                    tooltip="Geofence boundary",
+                ).add_to(_m)
+                folium.Marker(
+                    [fence_lat, fence_lon],
+                    tooltip="Formation location",
+                    icon=folium.Icon(
+                        color="green" if within else "red",
+                        icon="flag",
+                        prefix="fa",
+                    ),
+                ).add_to(_m)
 
-    st_folium(_m, width=None, height=300, key="checkin_map")
+        st_folium(_m, width=None, height=300, key="checkin_map")
 
 # ── Submit ────────────────────────────────────────────────────────────────────
 

--- a/pages/3_Cadets.py
+++ b/pages/3_Cadets.py
@@ -25,6 +25,7 @@ from services.cadets import (
     import_cadets_from_roster,
     parse_roster_xlsx,
     analyze_roster_for_import,
+    send_temp_passwords_to_created_cadets,
     RANK_OPTIONS,
     RANK_TO_LEVEL,
 )
@@ -378,7 +379,7 @@ with tab_import:
     st.subheader("Import Cadets from Roster")
 
     if "import_result" in st.session_state:
-        result = st.session_state.pop("import_result")
+        result = st.session_state["import_result"]
         if result.get("created"):
             st.success(f"Created {len(result['created'])} account(s).")
             rows = [
@@ -387,6 +388,7 @@ with tab_import:
                     "Email": c["email"],
                     "Rank": c["rank"],
                     "Temp Password": c["temp_password"],
+                    "Emailed": "Yes" if c.get("emailed") else "No",
                 }
                 for c in result["created"]
             ]
@@ -404,9 +406,71 @@ with tab_import:
             st.error(f"{len(result['errors'])} error(s):")
             for err in result["errors"]:
                 st.write(f"- {err['name']} ({err['email']}): {err['reason']}")
+        if result.get("email_failures"):
+            st.warning(f"{len(result['email_failures'])} email failure(s):")
+            for err in result["email_failures"]:
+                st.write(f"- {err['name']} ({err['email']}): {err['reason']}")
+
+        # ---- Retroactive email prompt ----
+        created = result.get("created", [])
+        unemailed = [c for c in created if not c.get("emailed")]
+        if unemailed and not st.session_state.get("import_email_dismissed", False):
+            st.divider()
+            st.info(
+                f"{len(unemailed)} cadet(s) were created but not yet emailed their temporary passwords."
+            )
+            c1, c2 = st.columns([3, 7])
+            with c1:
+                email_clicked = st.button(
+                    "Email temporary passwords", key="retroactive_email_temp_pw"
+                )
+            with c2:
+                dismiss_clicked = st.button(
+                    "Dismiss", type="secondary", key="dismiss_pending_email"
+                )
+
+            if email_clicked:
+                remaining, failures = send_temp_passwords_to_created_cadets(
+                    unemailed
+                )
+                # Persist mutations back into session state
+                st.session_state["import_result"]["created"] = created
+                if failures:
+                    st.warning(f"{len(failures)} email(s) failed:")
+                    for err in failures:
+                        st.write(
+                            f"- {err['name']} ({err['email']}): {err['reason']}"
+                        )
+                if not remaining:
+                    st.success(
+                        "All temporary passwords emailed successfully."
+                    )
+                else:
+                    st.info(
+                        f"{len(remaining)} cadet(s) still need to be emailed."
+                    )
+
+            if dismiss_clicked:
+                st.session_state["import_email_dismissed"] = True
+                st.rerun()
+
+        st.divider()
+        if st.button("Clear import results", key="clear_import_result"):
+            st.session_state.pop("import_result", None)
+            st.session_state.pop("import_email_dismissed", None)
+            for key in list(st.session_state.keys()):
+                if key.startswith("roster_"):
+                    del st.session_state[key]
+            st.rerun()
 
     # ---- Step 1: Upload & preview ----
-    uploaded = st.file_uploader("Upload roster (.xlsx)", type=["xlsx"], key="roster_uploader")
+    # Hide the upload/preview UI while import results are being reviewed so
+    # that reruns (e.g. retroactive email buttons) don't redraw it below.
+    if "import_result" not in st.session_state:
+        uploaded = st.file_uploader("Upload roster (.xlsx)", type=["xlsx"], key="roster_uploader")
+    else:
+        uploaded = None
+
     if uploaded:
         cadets, parse_errors = parse_roster_xlsx(uploaded)
         if parse_errors:
@@ -523,6 +587,11 @@ with tab_import:
 
             # ---- Step 2: Confirm import ----
             st.divider()
+            email_temp_passwords = st.checkbox(
+                "Email temporary passwords to new cadets",
+                value=False,
+                key="roster_email_temp_passwords",
+            )
             if st.button("Confirm Import", type="primary"):
                 actions = [
                     st.session_state.get(
@@ -535,6 +604,7 @@ with tab_import:
                         preview,
                         actions,
                         actor_user=get_current_user(),
+                        email_temp_passwords=email_temp_passwords,
                     )
                 st.session_state.import_result = result
                 # Clean up preview state so a fresh upload starts clean

--- a/pages/8_User_Management.py
+++ b/pages/8_User_Management.py
@@ -598,6 +598,7 @@ else:
                     st.error("User no longer exists.")
                 else:
                     updates, temp_pw = build_password_updates()
+                    updates["force_password_change"] = True
                     before_user = dict(existing_user)
                     result = update_user(existing_user["_id"], updates)
                     if result is None:

--- a/pages/9_Account_Settings.py
+++ b/pages/9_Account_Settings.py
@@ -167,6 +167,7 @@ with st.form("change_password_form"):
             for field, msg in errors.items():
                 st.error(f"{field.replace('_', ' ').capitalize()}: {msg}")
         else:
+            updates["force_password_change"] = False
             result = update_user(user_doc["_id"], updates)
             if result is None:
                 st.error("Failed to update password (database unavailable).")
@@ -213,10 +214,13 @@ with st.form("change_password_form"):
                         raw["usernames"][email]["password_hash"] = updates[
                             "password_hash"
                         ]
+                        raw["usernames"][email]["force_password_change"] = False
                     except Exception:
                         logging.exception(
                             "Failed to sync password hash in session state"
                         )
+
+                st.session_state["logout"] = False
 
                 authenticator = st.session_state.get("authenticator")
                 if authenticator is not None:
@@ -230,3 +234,9 @@ with st.form("change_password_form"):
                         )
 
                 st.success("Password updated successfully.")
+
+                if user_doc.get("force_password_change"):
+                    st.session_state["post_password_reset_redirect"] = (
+                        "attendance_submission"
+                    )
+                    st.rerun()

--- a/services/cadets.py
+++ b/services/cadets.py
@@ -21,6 +21,8 @@ from utils.db_schema_crud import (
 )
 from utils.names import format_full_name
 from utils.validators import is_valid_email, is_valid_name
+from utils.password_reset_email import send_temporary_password_email
+from services.email_templates import get_email_template, get_content
 
 RANK_OPTIONS = ("100", "150", "200", "250", "300", "400", "500", "700", "800", "900")
 
@@ -324,6 +326,7 @@ def import_cadets_from_roster(
     actions: list[str] | None = None,
     *,
     actor_user: dict[str, Any] | None = None,
+    email_temp_passwords: bool = False,
 ) -> dict:
     from utils.db_schema_crud import create_user
 
@@ -331,6 +334,7 @@ def import_cadets_from_roster(
     updated: list[dict] = []
     skipped: list[dict] = []
     errors: list[dict] = []
+    email_failures: list[dict] = []
 
     for i, cadet in enumerate(cadets_data):
         # Backward-compatible: raw dicts without analysis get the old behavior
@@ -512,6 +516,7 @@ def import_cadets_from_roster(
                     }
                 )
                 continue
+            update_user(user_result.inserted_id, {"force_password_change": True})
             created_user = get_user_by_id(user_result.inserted_id)
             target_label = format_full_name(cadet, default=email)
             _log_roster_import_change(
@@ -546,8 +551,30 @@ def import_cadets_from_roster(
                     "email": email,
                     "rank": rank,
                     "temp_password": temp_password,
+                    "emailed": False,
                 }
             )
+            if email_temp_passwords:
+                template = get_email_template("roster_temp_password")
+                subject, body = get_content(
+                    template, temporary_password=temp_password
+                )
+                sent = send_temporary_password_email(
+                    to_email=email,
+                    temporary_password=temp_password,
+                    subject=subject,
+                    body=body,
+                )
+                if sent:
+                    created[-1]["emailed"] = True
+                else:
+                    email_failures.append(
+                        {
+                            "name": full_name,
+                            "email": email,
+                            "reason": "Failed to send temporary password email",
+                        }
+                    )
         except Exception as e:
             errors.append(
                 {
@@ -557,4 +584,46 @@ def import_cadets_from_roster(
                 }
             )
 
-    return {"created": created, "updated": updated, "skipped": skipped, "errors": errors}
+    return {
+        "created": created,
+        "updated": updated,
+        "skipped": skipped,
+        "errors": errors,
+        "email_failures": email_failures,
+    }
+
+
+def send_temp_passwords_to_created_cadets(
+    created: list[dict],
+) -> tuple[list[dict], list[dict]]:
+    """Email temporary passwords to created cadets that haven't been emailed yet.
+
+    Mutates each dict in *created* to set ``emailed`` to ``True`` on success.
+
+    Returns ``(pending, failures)`` where *pending* is the subset of *created*
+    still not emailed and *failures* describes the send attempts that failed.
+    """
+    failures: list[dict] = []
+    template = get_email_template("roster_temp_password")
+    for c in created:
+        if c.get("emailed"):
+            continue
+        subject, body = get_content(template, temporary_password=c["temp_password"])
+        sent = send_temporary_password_email(
+            to_email=c["email"],
+            temporary_password=c["temp_password"],
+            subject=subject,
+            body=body,
+        )
+        if sent:
+            c["emailed"] = True
+        else:
+            failures.append(
+                {
+                    "name": c["name"],
+                    "email": c["email"],
+                    "reason": "Failed to send temporary password email",
+                }
+            )
+    pending = [c for c in created if not c.get("emailed")]
+    return pending, failures

--- a/services/email_templates.py
+++ b/services/email_templates.py
@@ -22,6 +22,10 @@ _DEFAULT_TEMPLATES = {
         "subject": "RollCall — Test Email",
         "body": "This is a test email from RollCall. SMTP is configured correctly.",
     },
+    "roster_temp_password": {
+        "subject": "RollCall — Your Temporary Password",
+        "body": "Hi,\n\nYour RollCall account has been created. Use the temporary password below to log in, then change it in Account Settings:\n\n{temporary_password}\n\nRollCall",
+    },
 }
 
 

--- a/tests/test_email_templates.py
+++ b/tests/test_email_templates.py
@@ -1,0 +1,19 @@
+from services.email_templates import (
+    _DEFAULT_TEMPLATES,
+    get_content,
+)
+
+
+def test_roster_temp_password_default_template_exists():
+    template = _DEFAULT_TEMPLATES["roster_temp_password"]
+    assert "RollCall" in template["subject"]
+    assert "{temporary_password}" in template["body"]
+
+
+def test_get_content_substitutes_temporary_password():
+    template = _DEFAULT_TEMPLATES["roster_temp_password"]
+    subject, body = get_content(template, temporary_password="abc123")
+    assert "RollCall" in subject
+    assert "abc123" in body
+    assert "{temporary_password}" not in body
+    assert "{temporary_password}" not in subject

--- a/tests/test_password_reset_email.py
+++ b/tests/test_password_reset_email.py
@@ -1,0 +1,100 @@
+import smtplib
+from unittest.mock import MagicMock, patch
+
+from utils.password_reset_email import (
+    send_temporary_password_email,
+)
+
+
+def test_returns_false_when_email_disabled():
+    with patch("utils.password_reset_email.is_email_enabled", return_value=False):
+        result = send_temporary_password_email(
+            to_email="user@example.com", temporary_password="abc123"
+        )
+    assert result is False
+
+
+def test_uses_custom_subject_and_body():
+    mock_server = MagicMock()
+    with (
+        patch("utils.password_reset_email.is_email_enabled", return_value=True),
+        patch(
+            "utils.password_reset_email._get_sender_credentials",
+            return_value=("sender@example.com", "password"),
+        ),
+        patch(
+            "utils.password_reset_email.smtplib.SMTP_SSL",
+            return_value=MagicMock(
+                __enter__=lambda s, *a: mock_server,
+                __exit__=MagicMock(return_value=False),
+            ),
+        ),
+    ):
+        result = send_temporary_password_email(
+            to_email="user@example.com",
+            temporary_password="abc123",
+            subject="Custom Subject",
+            body="Custom Body abc123",
+        )
+    assert result is True
+    sent_msg = mock_server.sendmail.call_args[0][2]
+    assert "Custom Subject" in sent_msg
+    assert "Custom Body abc123" in sent_msg
+
+
+def test_falls_back_to_defaults_when_subject_and_body_omitted():
+    mock_server = MagicMock()
+    with (
+        patch("utils.password_reset_email.is_email_enabled", return_value=True),
+        patch(
+            "utils.password_reset_email._get_sender_credentials",
+            return_value=("sender@example.com", "password"),
+        ),
+        patch(
+            "utils.password_reset_email.smtplib.SMTP_SSL",
+            return_value=MagicMock(
+                __enter__=lambda s, *a: mock_server,
+                __exit__=MagicMock(return_value=False),
+            ),
+        ),
+    ):
+        result = send_temporary_password_email(
+            to_email="user@example.com",
+            temporary_password="abc123",
+        )
+    assert result is True
+    sent_msg = mock_server.sendmail.call_args[0][2]
+    assert "RollCall Temporary Password" in sent_msg
+    assert "abc123" in sent_msg
+
+
+def test_returns_false_when_credentials_missing():
+    with (
+        patch("utils.password_reset_email.is_email_enabled", return_value=True),
+        patch(
+            "utils.password_reset_email._get_sender_credentials",
+            return_value=(None, None),
+        ),
+    ):
+        result = send_temporary_password_email(
+            to_email="user@example.com", temporary_password="abc123"
+        )
+    assert result is False
+
+
+def test_returns_false_on_smtp_exception():
+    with (
+        patch("utils.password_reset_email.is_email_enabled", return_value=True),
+        patch(
+            "utils.password_reset_email._get_sender_credentials",
+            return_value=("sender@example.com", "password"),
+        ),
+        patch(
+            "utils.password_reset_email.smtplib.SMTP_SSL",
+            side_effect=smtplib.SMTPException("connection failed"),
+        ),
+    ):
+        result = send_temporary_password_email(
+            to_email="user@example.com", temporary_password="abc123"
+        )
+    assert result is False

--- a/tests/test_roster_import.py
+++ b/tests/test_roster_import.py
@@ -201,9 +201,11 @@ def test_import_skips_existing_user(mock_get_cadet, mock_create_cadet, mock_get_
 @patch("services.cadets.get_cadet_by_id")
 @patch("services.cadets.get_user_by_id")
 @patch("services.cadets.log_data_change")
+@patch("services.cadets.update_user")
 @patch("utils.db_schema_crud.create_user")
 def test_import_creates_user_and_cadet(
     mock_create_user,
+    mock_update_user,
     mock_log_data_change,
     mock_get_user_by_id,
     mock_get_cadet_by_id,
@@ -237,7 +239,11 @@ def test_import_creates_user_and_cadet(
     assert "temp_password" in result["created"][0]
     assert result["skipped"] == []
     assert result["errors"] == []
+    assert result["email_failures"] == []
     assert mock_log_data_change.call_count == 2
+    mock_update_user.assert_called_once()
+    call_args = mock_update_user.call_args
+    assert call_args[0][1] == {"force_password_change": True}
 
 
 @patch("services.cadets.get_user_by_email")
@@ -453,3 +459,151 @@ def test_roster_import_action_config_exports():
         "Update",
         "Create as New",
     ]
+
+
+# -- email temp passwords on import
+
+
+@patch("services.cadets.get_user_by_email")
+@patch("services.cadets.create_cadet")
+@patch("services.cadets.get_cadet_by_id")
+@patch("services.cadets.get_user_by_id")
+@patch("services.cadets.log_data_change")
+@patch("services.cadets.update_user")
+@patch("services.cadets.send_temporary_password_email")
+@patch("utils.db_schema_crud.create_user")
+def test_import_does_not_email_when_flag_false(
+    mock_create_user,
+    mock_send_email,
+    mock_update_user,
+    mock_log_data_change,
+    mock_get_user_by_id,
+    mock_get_cadet_by_id,
+    mock_create_cadet,
+    mock_get_user,
+):
+    mock_get_user.return_value = None
+    inserted = MagicMock()
+    inserted.inserted_id = MagicMock()
+    created_cadet_result = MagicMock()
+    created_cadet_result.inserted_id = MagicMock()
+    mock_create_cadet.return_value = created_cadet_result
+    mock_create_user.return_value = inserted
+    mock_get_user_by_id.return_value = {"_id": inserted.inserted_id, "email": "jdoe@kent.edu"}
+    mock_get_cadet_by_id.return_value = {
+        "_id": created_cadet_result.inserted_id,
+        "email": "jdoe@kent.edu",
+    }
+    result = import_cadets_from_roster(
+        [
+            {
+                "first_name": "John",
+                "last_name": "Doe",
+                "email": "jdoe@kent.edu",
+                "rank": "100/150 (freshman)",
+            }
+        ],
+        email_temp_passwords=False,
+    )
+    assert len(result["created"]) == 1
+    mock_send_email.assert_not_called()
+    assert result["email_failures"] == []
+
+
+@patch("services.cadets.get_user_by_email")
+@patch("services.cadets.create_cadet")
+@patch("services.cadets.get_cadet_by_id")
+@patch("services.cadets.get_user_by_id")
+@patch("services.cadets.log_data_change")
+@patch("services.cadets.update_user")
+@patch("services.cadets.send_temporary_password_email")
+@patch("utils.db_schema_crud.create_user")
+def test_import_emails_temp_password_when_flag_true(
+    mock_create_user,
+    mock_send_email,
+    mock_update_user,
+    mock_log_data_change,
+    mock_get_user_by_id,
+    mock_get_cadet_by_id,
+    mock_create_cadet,
+    mock_get_user,
+):
+    mock_get_user.return_value = None
+    inserted = MagicMock()
+    inserted.inserted_id = MagicMock()
+    created_cadet_result = MagicMock()
+    created_cadet_result.inserted_id = MagicMock()
+    mock_create_cadet.return_value = created_cadet_result
+    mock_create_user.return_value = inserted
+    mock_get_user_by_id.return_value = {"_id": inserted.inserted_id, "email": "jdoe@kent.edu"}
+    mock_get_cadet_by_id.return_value = {
+        "_id": created_cadet_result.inserted_id,
+        "email": "jdoe@kent.edu",
+    }
+    mock_send_email.return_value = True
+    result = import_cadets_from_roster(
+        [
+            {
+                "first_name": "John",
+                "last_name": "Doe",
+                "email": "jdoe@kent.edu",
+                "rank": "100/150 (freshman)",
+            }
+        ],
+        email_temp_passwords=True,
+    )
+    assert len(result["created"]) == 1
+    mock_send_email.assert_called_once()
+    call_kwargs = mock_send_email.call_args.kwargs
+    assert call_kwargs["to_email"] == "jdoe@kent.edu"
+    assert "temporary_password" in call_kwargs
+    assert call_kwargs["subject"] is not None
+    assert call_kwargs["body"] is not None
+    assert result["email_failures"] == []
+
+
+@patch("services.cadets.get_user_by_email")
+@patch("services.cadets.create_cadet")
+@patch("services.cadets.get_cadet_by_id")
+@patch("services.cadets.get_user_by_id")
+@patch("services.cadets.log_data_change")
+@patch("services.cadets.update_user")
+@patch("services.cadets.send_temporary_password_email")
+@patch("utils.db_schema_crud.create_user")
+def test_import_collects_email_failures(
+    mock_create_user,
+    mock_send_email,
+    mock_update_user,
+    mock_log_data_change,
+    mock_get_user_by_id,
+    mock_get_cadet_by_id,
+    mock_create_cadet,
+    mock_get_user,
+):
+    mock_get_user.return_value = None
+    inserted = MagicMock()
+    inserted.inserted_id = MagicMock()
+    created_cadet_result = MagicMock()
+    created_cadet_result.inserted_id = MagicMock()
+    mock_create_cadet.return_value = created_cadet_result
+    mock_create_user.return_value = inserted
+    mock_get_user_by_id.return_value = {"_id": inserted.inserted_id, "email": "jdoe@kent.edu"}
+    mock_get_cadet_by_id.return_value = {
+        "_id": created_cadet_result.inserted_id,
+        "email": "jdoe@kent.edu",
+    }
+    mock_send_email.return_value = False
+    result = import_cadets_from_roster(
+        [
+            {
+                "first_name": "John",
+                "last_name": "Doe",
+                "email": "jdoe@kent.edu",
+                "rank": "100/150 (freshman)",
+            }
+        ],
+        email_temp_passwords=True,
+    )
+    assert len(result["created"]) == 1
+    assert len(result["email_failures"]) == 1
+    assert result["email_failures"][0]["email"] == "jdoe@kent.edu"

--- a/utils/auth_logic.py
+++ b/utils/auth_logic.py
@@ -40,6 +40,7 @@ def extract_user_from_raw(email: str | None, raw: dict) -> dict | None:
         "last_name": str(user_info.get("last_name", "")),
         "roles": list(user_info.get("roles", [])),
         "disabled": bool(user_info.get("disabled", False)),
+        "force_password_change": bool(user_info.get("force_password_change", False)),
     }
 
 

--- a/utils/password_reset_email.py
+++ b/utils/password_reset_email.py
@@ -7,6 +7,8 @@ from urllib.parse import quote
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 
+from services.event_config import is_email_enabled
+
 
 def _get_sender_credentials() -> tuple[str | None, str | None]:
     sender_email = os.getenv("EMAIL_ADDRESS")
@@ -63,14 +65,23 @@ def send_password_reset_email(*, to_email: str, token: str) -> bool:
     return _send_message(to_email, msg)
 
 
-def send_temporary_password_email(*, to_email: str, temporary_password: str) -> bool:
+def send_temporary_password_email(
+    *,
+    to_email: str,
+    temporary_password: str,
+    subject: str | None = None,
+    body: str | None = None,
+) -> bool:
+    if not is_email_enabled():
+        return False
+
     msg = MIMEMultipart("alternative")
     sender_email, _ = _get_sender_credentials()
     msg["From"] = sender_email or ""
     msg["To"] = to_email
-    msg["Subject"] = "RollCall Temporary Password"
+    msg["Subject"] = subject or "RollCall Temporary Password"
 
-    body = (
+    email_body = body or (
         "Hi,\n\n"
         "An admin has reset your password. "
         "Use the temporary password below to log in, then change it in Account Settings:\n\n"
@@ -78,5 +89,5 @@ def send_temporary_password_email(*, to_email: str, temporary_password: str) -> 
         "RollCall"
     )
 
-    msg.attach(MIMEText(body, "plain"))
+    msg.attach(MIMEText(email_body, "plain"))
     return _send_message(to_email, msg)


### PR DESCRIPTION
This PR adds support for emailing temporary passwords when cadets are created from a roster import, including a new configurable email template and follow-up handling for failed sends. It also enforces first-login password changes for temporary-password users by limiting access until they update their password, with tests covering the new import, email, and template flows.

also added an indicator whether location was found and fix the error when its not found on attendance submission.

closes #281 