### PR TITLE
Add standing waivers over a date range

### DIFF
--- a/pages/5_Waivers.py
+++ b/pages/5_Waivers.py
@@ -39,9 +39,7 @@ STATUS_BADGE = WAIVER_STATUS_BADGE
 require_role("cadet")
 
 
-def load_waiver_data(
-    cadet_id, user_id
-) -> tuple[list[dict], dict, list[dict], dict]:
+def load_waiver_data(cadet_id, user_id) -> tuple[list[dict], dict, list[dict], dict]:
     records = get_attendance_by_cadet(cadet_id)
     waivers_by_record_id = {}
     all_waivers: list[dict] = []
@@ -83,14 +81,10 @@ def show_waivers(
             start = w.get("start_date")
             end = w.get("end_date")
             start_str = (
-                start.strftime("%Y-%m-%d")
-                if isinstance(start, datetime)
-                else "Unknown"
+                start.strftime("%Y-%m-%d") if isinstance(start, datetime) else "Unknown"
             )
             end_str = (
-                end.strftime("%Y-%m-%d")
-                if isinstance(end, datetime)
-                else "Unknown"
+                end.strftime("%Y-%m-%d") if isinstance(end, datetime) else "Unknown"
             )
             entry["_event_name"] = "Standing waiver"
             entry["_event_date"] = f"{start_str} → {end_str}"
@@ -307,7 +301,9 @@ def _build_attachments(uploaded_file) -> list[dict]:
     ]
 
 
-def _build_reason_text(common_reasons: list[str], selected_reason: str, extra: str) -> str:
+def _build_reason_text(
+    common_reasons: list[str], selected_reason: str, extra: str
+) -> str:
     if selected_reason == common_reasons[-1]:
         return extra.strip()
     return f"{selected_reason}. {extra}".strip(". ")
@@ -336,9 +332,7 @@ def _submit_singular_waiver(
                 f"Waiver is still invalid and was auto-denied again: {why}"
             )
         else:
-            st.session_state.show_success = (
-                "Waiver request submitted successfully!"
-            )
+            st.session_state.show_success = "Waiver request submitted successfully!"
         st.rerun()
 
     result = create_waiver(
@@ -406,7 +400,9 @@ def _submit_standing_waiver(
     else:
         if waiver_type == "sickness":
             apply_sickness_auto_approval(result.inserted_id, user_id)
-        st.session_state.show_success = "Standing waiver request submitted successfully!"
+        st.session_state.show_success = (
+            "Standing waiver request submitted successfully!"
+        )
     st.rerun()
 
 
@@ -552,7 +548,9 @@ def waiver_form(
                 standing_range, today, today
             )
             if not range_complete:
-                st.error("Select a complete start and end date for the standing waiver.")
+                st.error(
+                    "Select a complete start and end date for the standing waiver."
+                )
             elif not standing_event_types:
                 st.error("Select at least one event type for the standing waiver.")
             else:

--- a/pages/5_Waivers.py
+++ b/pages/5_Waivers.py
@@ -403,6 +403,12 @@ def _submit_standing_waiver(
         st.session_state.show_success = (
             "Standing waiver request submitted successfully!"
         )
+        for key in (
+            "waiver_standing_toggle",
+            "waiver_standing_range",
+            "waiver_standing_event_types",
+        ):
+            st.session_state.pop(key, None)
     st.rerun()
 
 
@@ -440,21 +446,64 @@ def waiver_form(
     today = datetime.now(timezone.utc).date()
     common_reasons = get_common_reasons()
 
+    standing_range = None
+    standing_event_types: list[str] = []
+    standing_error: str | None = None
+    standing_ready = False
+
+    if is_standing_mode:
+        standing_range = st.date_input(
+            "Standing waiver date range",
+            value=(today, today + timedelta(days=7)),
+            key="waiver_standing_range",
+            help="Inclusive start and end dates. Only PT/LLAB days in the range are covered.",
+        )
+        standing_event_types = st.multiselect(
+            "Event types covered",
+            options=["pt", "lab"],
+            default=["pt", "lab"],
+            format_func=lambda t: {"pt": "PT", "lab": "LLAB"}.get(t, t),
+            key="waiver_standing_event_types",
+        )
+
+        parsed_start, parsed_end, range_complete = parse_streamlit_date_range(
+            standing_range, today, today
+        )
+        if not range_complete:
+            st.info("Select an end date to preview the covered events.")
+        elif not standing_event_types:
+            standing_error = "Select at least one event type for the standing waiver."
+            st.error(standing_error)
+        else:
+            is_valid, why = validate_standing_waiver(
+                parsed_start, parsed_end, standing_event_types
+            )
+            if not is_valid:
+                standing_error = why
+                st.error(why)
+            else:
+                preview = compute_standing_waiver_dates(
+                    parsed_start, parsed_end, standing_event_types
+                )
+                st.caption(f"This waiver would cover {len(preview)} event(s).")
+                if preview:
+                    preview_rows = [
+                        {
+                            "Date": p["date"].strftime("%Y-%m-%d"),
+                            "Day": p["day"],
+                            "Type": p["type"],
+                        }
+                        for p in preview
+                    ]
+                    st.dataframe(
+                        pd.DataFrame(preview_rows),
+                        hide_index=True,
+                        width="stretch",
+                    )
+                standing_ready = True
+
     with st.form("waiver_form", clear_on_submit=True):
         if is_standing_mode:
-            standing_range = st.date_input(
-                "Standing waiver date range",
-                value=(today, today + timedelta(days=7)),
-                key="waiver_standing_range",
-                help="Inclusive start and end dates. Only PT/LLAB days in the range are covered.",
-            )
-            standing_event_types = st.multiselect(
-                "Event types covered",
-                options=["pt", "lab"],
-                default=["pt", "lab"],
-                format_func=lambda t: {"pt": "PT", "lab": "LLAB"}.get(t, t),
-                key="waiver_standing_event_types",
-            )
             label = ""
         else:
             label = st.selectbox(
@@ -462,8 +511,6 @@ def waiver_form(
                 options=list(record_labels.keys()),
                 index=default_index,
             )
-            standing_range = None
-            standing_event_types = []
 
         waiver_type = st.radio(
             "Waiver type",
@@ -513,47 +560,26 @@ def waiver_form(
         with col2:
             cancel = st.form_submit_button("Cancel", type="secondary")
 
-    if is_standing_mode and standing_range is not None:
-        parsed_start, parsed_end, range_complete = parse_streamlit_date_range(
-            standing_range, today, today
-        )
-        if range_complete:
-            preview = compute_standing_waiver_dates(
-                parsed_start, parsed_end, standing_event_types
-            )
-            st.caption(f"This waiver would cover {len(preview)} event(s).")
-            if preview:
-                preview_rows = [
-                    {
-                        "Date": p["date"].strftime("%Y-%m-%d"),
-                        "Day": p["day"],
-                        "Type": p["type"],
-                    }
-                    for p in preview
-                ]
-                st.dataframe(
-                    pd.DataFrame(preview_rows),
-                    hide_index=True,
-                    width="stretch",
-                )
-        else:
-            st.info("Select an end date to preview the covered events.")
-
     if submit:
         reason_text = _build_reason_text(common_reasons, selected_reason, extra_details)
         if not reason_text:
-            st.error("Please provide a reason for your waiver request.")
-        elif is_standing_mode:
-            parsed_start, parsed_end, range_complete = parse_streamlit_date_range(
-                standing_range, today, today
+            st.session_state.show_error = (
+                "Please provide a reason for your waiver request."
             )
-            if not range_complete:
-                st.error(
+            st.rerun()
+        elif is_standing_mode:
+            if standing_error:
+                st.session_state.show_error = standing_error
+                st.rerun()
+            elif not standing_ready:
+                st.session_state.show_error = (
                     "Select a complete start and end date for the standing waiver."
                 )
-            elif not standing_event_types:
-                st.error("Select at least one event type for the standing waiver.")
+                st.rerun()
             else:
+                parsed_start, parsed_end, _ = parse_streamlit_date_range(
+                    standing_range, today, today
+                )
                 _submit_standing_waiver(
                     user_id=user_id,
                     start=parsed_start,
@@ -591,13 +617,6 @@ if "show_success" not in st.session_state:
 if "show_error" not in st.session_state:
     st.session_state.show_error = None
 
-if st.session_state.show_success:
-    st.success(st.session_state.show_success)
-    st.session_state.show_success = None
-if st.session_state.show_error:
-    st.error(st.session_state.show_error)
-    st.session_state.show_error = None
-
 current_user = get_current_user()
 assert current_user is not None
 
@@ -625,3 +644,10 @@ with st.expander(
     "Submit New Waiver Request", expanded=st.session_state.waiver_record_id is not None
 ):
     waiver_form(str(user["_id"]), records, waivers_by_record_id, events_by_id)
+
+if st.session_state.show_success:
+    st.success(st.session_state.show_success)
+    st.session_state.show_success = None
+if st.session_state.show_error:
+    st.error(st.session_state.show_error)
+    st.session_state.show_error = None

--- a/pages/5_Waivers.py
+++ b/pages/5_Waivers.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, time, timedelta, timezone
 
 import pandas as pd
 import streamlit as st
@@ -9,20 +9,24 @@ from services.admin_users import confirm_destructive_action
 from services.waivers import (
     WAIVER_STATUS_BADGE,
     apply_sickness_auto_approval,
+    compute_standing_waiver_dates,
     get_absent_records_without_waiver,
     get_common_reasons,
     resolve_cadre_only,
     resubmit_auto_denied_waiver,
+    validate_standing_waiver,
     withdraw_waiver,
 )
 from utils.auth import get_current_user, require_role
 from utils.auth_logic import user_has_any_role
+from utils.date_range import parse_streamlit_date_range
 from utils.db_schema_crud import (
     create_waiver,
     get_approvals_by_waiver,
     get_attendance_by_cadet,
     get_cadet_by_user_id,
     get_event_by_id,
+    get_standing_waivers_by_user,
     get_user_by_email,
     get_waiver_by_attendance_record,
     get_waiver_by_id,
@@ -35,7 +39,9 @@ STATUS_BADGE = WAIVER_STATUS_BADGE
 require_role("cadet")
 
 
-def load_waiver_data(cadet_id) -> tuple[list[dict], dict, list[dict], dict]:
+def load_waiver_data(
+    cadet_id, user_id
+) -> tuple[list[dict], dict, list[dict], dict]:
     records = get_attendance_by_cadet(cadet_id)
     waivers_by_record_id = {}
     all_waivers: list[dict] = []
@@ -57,6 +63,8 @@ def load_waiver_data(cadet_id) -> tuple[list[dict], dict, list[dict], dict]:
             if event:
                 events_by_id[event_id] = event
 
+    all_waivers.extend(get_standing_waivers_by_user(user_id))
+
     return records, waivers_by_record_id, all_waivers, events_by_id
 
 
@@ -70,13 +78,31 @@ def show_waivers(
 
     waivers = []
     for w in all_waivers:
+        entry = dict(w)
+        if w.get("is_standing"):
+            start = w.get("start_date")
+            end = w.get("end_date")
+            start_str = (
+                start.strftime("%Y-%m-%d")
+                if isinstance(start, datetime)
+                else "Unknown"
+            )
+            end_str = (
+                end.strftime("%Y-%m-%d")
+                if isinstance(end, datetime)
+                else "Unknown"
+            )
+            entry["_event_name"] = "Standing waiver"
+            entry["_event_date"] = f"{start_str} → {end_str}"
+            waivers.append(entry)
+            continue
+
         record = next(
             (r for r in records if r["_id"] == w.get("attendance_record_id")), None
         )
         if record is None:
             continue
         event = events_by_id.get(record.get("event_id"))
-        entry = dict(w)
         entry["_event_name"] = event.get("event_name") if event else "Unknown event"
         entry["_event_date"] = (
             event.get("start_date").strftime("%Y-%m-%d")
@@ -118,56 +144,11 @@ def show_waivers(
             value=(default_start, today),
         )
 
-    # Streamlit returns a single date while the user is mid-selecting a range.
-    start_date: date = default_start
-    end_date: date = today
-
-    if isinstance(date_value, date):
-        start_date = date_value
-        end_date = today
+    start_date, end_date, range_complete = parse_streamlit_date_range(
+        date_value, default_start, today
+    )
+    if not range_complete:
         st.info("Select an end date to complete the range (using today for now).")
-    elif isinstance(date_value, tuple):
-        match date_value:
-            case (start, end):
-                start_date = start
-                end_date = end
-            case (start,):
-                start_date = start
-                end_date = today
-                st.info(
-                    "Select an end date to complete the range (using today for now)."
-                )
-            case _:
-                start_date = default_start
-                end_date = today
-                st.info(
-                    "Select an end date to complete the range (using today for now)."
-                )
-    elif isinstance(date_value, list):
-        match tuple(date_value):
-            case (start, end):
-                start_date = start
-                end_date = end
-            case (start,):
-                start_date = start
-                end_date = today
-                st.info(
-                    "Select an end date to complete the range (using today for now)."
-                )
-            case _:
-                start_date = default_start
-                end_date = today
-                st.info(
-                    "Select an end date to complete the range (using today for now)."
-                )
-    else:
-        start_date = default_start
-        end_date = today
-        st.info("Select an end date to complete the range (using today for now).")
-
-    if start_date > end_date:
-        # Be forgiving for mid-selection / accidental reversal.
-        start_date, end_date = end_date, start_date
 
     with filter_col3:
         search = st.text_input("Search (event)", value="")
@@ -314,6 +295,121 @@ def dropdown_row(record: dict, events_by_id: dict) -> str:
     return str(record["_id"])
 
 
+def _build_attachments(uploaded_file) -> list[dict]:
+    if uploaded_file is None:
+        return []
+    return [
+        {
+            "filename": uploaded_file.name,
+            "content_type": uploaded_file.type or "application/octet-stream",
+            "data": uploaded_file.read(),
+        }
+    ]
+
+
+def _build_reason_text(common_reasons: list[str], selected_reason: str, extra: str) -> str:
+    if selected_reason == common_reasons[-1]:
+        return extra.strip()
+    return f"{selected_reason}. {extra}".strip(". ")
+
+
+def _submit_singular_waiver(
+    *,
+    user_id: str,
+    selected_record: dict,
+    reason_text: str,
+    waiver_type: str,
+    cadre_only: bool,
+    attachments: list[dict],
+):
+    existing = get_waiver_by_attendance_record(selected_record["_id"])
+    if (
+        existing
+        and (existing.get("status") or "").lower() == "denied"
+        and bool(existing.get("auto_denied"))
+    ):
+        became_pending, why = resubmit_auto_denied_waiver(
+            existing, selected_record["_id"], reason_text
+        )
+        if not became_pending:
+            st.session_state.show_error = (
+                f"Waiver is still invalid and was auto-denied again: {why}"
+            )
+        else:
+            st.session_state.show_success = (
+                "Waiver request submitted successfully!"
+            )
+        st.rerun()
+
+    result = create_waiver(
+        attendance_record_id=selected_record["_id"],
+        reason=reason_text,
+        status="pending",
+        submitted_by_user_id=user_id,
+        waiver_type=waiver_type,
+        cadre_only=cadre_only,
+        attachments=attachments,
+    )
+    if not result:
+        st.session_state.show_error = "Failed to submit waiver. Please try again."
+        st.rerun()
+        return
+
+    created = get_waiver_by_id(result.inserted_id)
+    created_status = (created.get("status") if created else "") or ""
+    if created_status.lower() == "denied":
+        st.session_state.show_error = (
+            "Waiver was auto-denied. See notes under your waiver status."
+        )
+    else:
+        if waiver_type == "sickness":
+            apply_sickness_auto_approval(result.inserted_id, user_id)
+        st.session_state.show_success = "Waiver request submitted successfully!"
+    st.rerun()
+
+
+def _submit_standing_waiver(
+    *,
+    user_id: str,
+    start: date,
+    end: date,
+    event_types: list[str],
+    reason_text: str,
+    waiver_type: str,
+    cadre_only: bool,
+    attachments: list[dict],
+):
+    is_valid, why = validate_standing_waiver(start, end, event_types)
+    if not is_valid:
+        st.session_state.show_error = f"Standing waiver invalid: {why}"
+        st.rerun()
+        return
+
+    start_dt = datetime.combine(start, time.min, tzinfo=timezone.utc)
+    end_dt = datetime.combine(end, time.max, tzinfo=timezone.utc)
+
+    result = create_waiver(
+        attendance_record_id=None,
+        reason=reason_text,
+        status="pending",
+        submitted_by_user_id=user_id,
+        waiver_type=waiver_type,
+        cadre_only=cadre_only,
+        attachments=attachments,
+        is_standing=True,
+        start_date=start_dt,
+        end_date=end_dt,
+        event_types=event_types,
+    )
+    if not result:
+        st.session_state.show_error = "Failed to submit waiver. Please try again."
+    else:
+        if waiver_type == "sickness":
+            apply_sickness_auto_approval(result.inserted_id, user_id)
+        st.session_state.show_success = "Standing waiver request submitted successfully!"
+    st.rerun()
+
+
 def waiver_form(
     user_id: str,
     records: list[dict],
@@ -324,27 +420,54 @@ def waiver_form(
     st.session_state.waiver_record_id = None
 
     absent_records = get_absent_records_without_waiver(records, waivers_by_record_id)
-    if not absent_records:
+    is_standing_mode = st.toggle(
+        "Standing waiver (covers a date range)",
+        value=False,
+        key="waiver_standing_toggle",
+        help="Use a standing waiver when you'll be absent for an extended span of PT/LLAB days.",
+    )
+
+    if not is_standing_mode and not absent_records:
         st.info("You don't have any absent records to submit a waiver for.")
         return
 
-    record_labels = {dropdown_row(r, events_by_id): r for r in absent_records}
-
+    record_labels: dict[str, dict] = {}
     default_index = 0
-    if record_id:
-        for i, record in enumerate(absent_records):
-            if str(record["_id"]) == record_id:
-                default_index = i
-                break
+    if not is_standing_mode:
+        record_labels = {dropdown_row(r, events_by_id): r for r in absent_records}
+        if record_id:
+            for i, record in enumerate(absent_records):
+                if str(record["_id"]) == record_id:
+                    default_index = i
+                    break
 
+    today = datetime.now(timezone.utc).date()
     common_reasons = get_common_reasons()
 
     with st.form("waiver_form", clear_on_submit=True):
-        label = st.selectbox(
-            "Select Absent Event",
-            options=list(record_labels.keys()),
-            index=default_index,
-        )
+        if is_standing_mode:
+            standing_range = st.date_input(
+                "Standing waiver date range",
+                value=(today, today + timedelta(days=7)),
+                key="waiver_standing_range",
+                help="Inclusive start and end dates. Only PT/LLAB days in the range are covered.",
+            )
+            standing_event_types = st.multiselect(
+                "Event types covered",
+                options=["pt", "lab"],
+                default=["pt", "lab"],
+                format_func=lambda t: {"pt": "PT", "lab": "LLAB"}.get(t, t),
+                key="waiver_standing_event_types",
+            )
+            label = ""
+        else:
+            label = st.selectbox(
+                "Select Absent Event",
+                options=list(record_labels.keys()),
+                index=default_index,
+            )
+            standing_range = None
+            standing_event_types = []
 
         waiver_type = st.radio(
             "Waiver type",
@@ -394,75 +517,64 @@ def waiver_form(
         with col2:
             cancel = st.form_submit_button("Cancel", type="secondary")
 
-    if submit:
-        reason_text = (
-            extra_details.strip()
-            if selected_reason == common_reasons[-1]
-            else f"{selected_reason}. {extra_details}".strip(". ")
+    if is_standing_mode and standing_range is not None:
+        parsed_start, parsed_end, range_complete = parse_streamlit_date_range(
+            standing_range, today, today
         )
+        if range_complete:
+            preview = compute_standing_waiver_dates(
+                parsed_start, parsed_end, standing_event_types
+            )
+            st.caption(f"This waiver would cover {len(preview)} event(s).")
+            if preview:
+                preview_rows = [
+                    {
+                        "Date": p["date"].strftime("%Y-%m-%d"),
+                        "Day": p["day"],
+                        "Type": p["type"],
+                    }
+                    for p in preview
+                ]
+                st.dataframe(
+                    pd.DataFrame(preview_rows),
+                    hide_index=True,
+                    width="stretch",
+                )
+        else:
+            st.info("Select an end date to preview the covered events.")
+
+    if submit:
+        reason_text = _build_reason_text(common_reasons, selected_reason, extra_details)
         if not reason_text:
             st.error("Please provide a reason for your waiver request.")
-        else:
-            selected_record = record_labels[label]
-            existing = get_waiver_by_attendance_record(selected_record["_id"])
-
-            attachments = []
-            if uploaded_file is not None:
-                attachments = [
-                    {
-                        "filename": uploaded_file.name,
-                        "content_type": uploaded_file.type
-                        or "application/octet-stream",
-                        "data": uploaded_file.read(),
-                    }
-                ]
-
-            if (
-                existing
-                and (existing.get("status") or "").lower() == "denied"
-                and bool(existing.get("auto_denied"))
-            ):
-                became_pending, why = resubmit_auto_denied_waiver(
-                    existing, selected_record["_id"], reason_text
-                )
-                if not became_pending:
-                    st.error(
-                        f"Waiver is still invalid and was auto-denied again: {why}"
-                    )
-                else:
-                    st.session_state.show_success = (
-                        "Waiver request submitted successfully!"
-                    )
-                st.rerun()
-
+        elif is_standing_mode:
+            parsed_start, parsed_end, range_complete = parse_streamlit_date_range(
+                standing_range, today, today
+            )
+            if not range_complete:
+                st.error("Select a complete start and end date for the standing waiver.")
+            elif not standing_event_types:
+                st.error("Select at least one event type for the standing waiver.")
             else:
-                result = create_waiver(
-                    attendance_record_id=selected_record["_id"],
-                    reason=reason_text,
-                    status="pending",
-                    submitted_by_user_id=user_id,
+                _submit_standing_waiver(
+                    user_id=user_id,
+                    start=parsed_start,
+                    end=parsed_end,
+                    event_types=standing_event_types,
+                    reason_text=reason_text,
                     waiver_type=waiver_type,
                     cadre_only=cadre_only,
-                    attachments=attachments,
+                    attachments=_build_attachments(uploaded_file),
                 )
-
-                if result:
-                    created = get_waiver_by_id(result.inserted_id)
-                    created_status = (created.get("status") if created else "") or ""
-                    if created_status.lower() == "denied":
-                        st.session_state.show_error = "Waiver was auto-denied. See notes under your waiver status."
-                    else:
-                        if waiver_type == "sickness":
-                            apply_sickness_auto_approval(result.inserted_id, user_id)
-                        st.session_state.show_success = (
-                            "Waiver request submitted successfully!"
-                        )
-                    st.rerun()
-                else:
-                    st.session_state.show_error = (
-                        "Failed to submit waiver. Please try again."
-                    )
-                    st.rerun()
+        else:
+            _submit_singular_waiver(
+                user_id=user_id,
+                selected_record=record_labels[label],
+                reason_text=reason_text,
+                waiver_type=waiver_type,
+                cadre_only=cadre_only,
+                attachments=_build_attachments(uploaded_file),
+            )
 
     if cancel:
         st.switch_page("pages/8_Cadet_Attendance.py")
@@ -506,7 +618,7 @@ if not cadet:
     cadet = get_temp_cadet()
 
 records, waivers_by_record_id, all_waivers, events_by_id = load_waiver_data(
-    cadet["_id"]
+    cadet["_id"], user["_id"]
 )
 show_waivers(records, all_waivers, events_by_id)
 

--- a/pages/6_Event_Management_CRUD.py
+++ b/pages/6_Event_Management_CRUD.py
@@ -24,6 +24,7 @@ from services.events import (
     update_event,
 )
 from utils.auth import require_role, get_current_user_doc
+from utils.date_range import parse_streamlit_date_range
 from utils.st_helpers import require
 
 require_role("admin", "cadre")
@@ -212,15 +213,11 @@ with st.expander("Generate Semester Schedule", expanded=False):
         key="gen_date_range",
     )
 
-    # st.date_input with a tuple value returns a tuple; guard partial selection
-    if isinstance(_gen_range, (list, tuple)) and len(_gen_range) == 2:
-        _gen_start: date | None = _gen_range[0]  # type: ignore
-        _gen_end: date | None = _gen_range[1]  # type: ignore
-        _range_complete = True
-    else:
-        _gen_start = None
-        _gen_end = None
-        _range_complete = False
+    _parsed_start, _parsed_end, _range_complete = parse_streamlit_date_range(
+        _gen_range, _today, _today
+    )
+    _gen_start: date | None = _parsed_start if _range_complete else None
+    _gen_end: date | None = _parsed_end if _range_complete else None
 
     st.divider()
 

--- a/pages/8_Cadet_Attendance.py
+++ b/pages/8_Cadet_Attendance.py
@@ -225,8 +225,10 @@ if not cadet:
         st.stop()
     cadet = get_temp_cadet()
 
-records, events, waivers = load_attendance_db(cadet["_id"])
-rows = cadet_attendance(records, events, waivers)
+records, events, waivers, standing_waivers = load_attendance_db(
+    cadet["_id"], user["_id"]
+)
+rows = cadet_attendance(records, events, waivers, standing_waivers)
 
 show_header(cadet, current_user)
 

--- a/scripts/seed_data_demo.py
+++ b/scripts/seed_data_demo.py
@@ -759,7 +759,9 @@ def _seed_audit_log(
 
     event_to_update = event_docs[0]
     event_before = dict(event_to_update)
-    event_to_update["event_name"] = f"{event_to_update['event_name']} - Leadership Focus"
+    event_to_update["event_name"] = (
+        f"{event_to_update['event_name']} - Leadership Focus"
+    )
     event_to_update["geofence_enabled"] = True
     event_to_update["geofence_lat"] = 40.7128
     event_to_update["geofence_lon"] = -74.0060
@@ -791,7 +793,9 @@ def _seed_audit_log(
     )
     audit_count += 1
 
-    event_to_archive = next(doc for doc in event_docs if doc["start_date"].date() >= TODAY)
+    event_to_archive = next(
+        doc for doc in event_docs if doc["start_date"].date() >= TODAY
+    )
     archived_before = dict(event_to_archive)
     event_to_archive["archived"] = True
     event_to_archive["archived_at"] = NOW - timedelta(days=3)
@@ -982,7 +986,11 @@ def _seed_audit_log(
     )
     audit_count += 1
 
-    code_event = next(doc for doc in event_docs if doc["start_date"].date() >= TODAY and not doc.get("archived"))
+    code_event = next(
+        doc
+        for doc in event_docs
+        if doc["start_date"].date() >= TODAY and not doc.get("archived")
+    )
     active_code_doc = {
         "code": "482915",
         "event_id": code_event["_id"],
@@ -1109,7 +1117,10 @@ def _seed_audit_log(
             before={"status": "pending", "waiver_type": row["waiver_type"]},
             after={"status": row["status"], "waiver_type": row["waiver_type"]},
             now=row["created_at"],
-            metadata={"waiver_id": str(row["waiver_id"]), "decision_comments": row["comments"]},
+            metadata={
+                "waiver_id": str(row["waiver_id"]),
+                "decision_comments": row["comments"],
+            },
         )
         audit_count += 1
 
@@ -1304,16 +1315,21 @@ def populate() -> None:
                     )
                 )
 
-    for record_id, cadet_key, _, _, in absent_records[:3]:
+    for (
+        record_id,
+        cadet_key,
+        _,
+        _,
+    ) in absent_records[:3]:
         new_status = "excused" if len(attendance_audit_rows) < 2 else "present"
         audit_time = NOW - timedelta(days=8 - len(attendance_audit_rows), hours=2)
         db["attendance_records"].update_one(
             {"_id": record_id},
             {"$set": {"status": new_status, "updated_at": audit_time}},
         )
-        event_id = db["attendance_records"].find_one({"_id": record_id}, {"event_id": 1})[
-            "event_id"
-        ]
+        event_id = db["attendance_records"].find_one(
+            {"_id": record_id}, {"event_id": 1}
+        )["event_id"]
         attendance_audit_rows.append(
             {
                 "record_id": record_id,
@@ -1430,8 +1446,7 @@ def populate() -> None:
                     "waiver_type": wtype,
                     "approver_id": user_id_by_key[approver_key],
                     "comments": comments,
-                    "created_at": NOW
-                    - timedelta(days=max(0, days_ago_submitted - 1)),
+                    "created_at": NOW - timedelta(days=max(0, days_ago_submitted - 1)),
                 }
             )
 

--- a/services/cadet_attendance.py
+++ b/services/cadet_attendance.py
@@ -1,27 +1,60 @@
 from datetime import datetime, timezone
 
+from utils.datetime_utils import ensure_utc
 from utils.db_schema_crud import (
     get_attendance_by_cadet,
     get_events_by_ids,
-    get_waivers_by_attendance_records,
     get_flight_by_id,
+    get_standing_waivers_by_user,
+    get_waivers_by_attendance_records,
 )
 from utils.attendance_status import get_effective_attendance_status
 from services.attendance_merge import merge_attendance_records
 
 
-def load_attendance_db(cadet_id: str) -> tuple[list[dict], list[dict], list[dict]]:
+def load_attendance_db(
+    cadet_id: str, user_id=None
+) -> tuple[list[dict], list[dict], list[dict], list[dict]]:
     records = get_attendance_by_cadet(cadet_id)
     if not records:
-        return [], [], []
+        return [], [], [], []
 
     event_ids = list({r["event_id"] for r in records})
     record_ids = [r["_id"] for r in records]
 
     events = get_events_by_ids(event_ids)
     waivers = get_waivers_by_attendance_records(record_ids)
+    standing_waivers = (
+        get_standing_waivers_by_user(user_id) if user_id is not None else []
+    )
 
-    return records, events, waivers
+    return records, events, waivers, standing_waivers
+
+
+def _covering_standing_waiver(
+    event: dict, standing_waivers: list[dict]
+) -> dict | None:
+    """Return the approved standing waiver that covers this event, if any."""
+    start = event.get("start_date")
+    if not isinstance(start, datetime):
+        return None
+    start = ensure_utc(start)
+    event_type = (event.get("event_type") or "").lower()
+
+    for waiver in standing_waivers:
+        if (waiver.get("status") or "").lower() != "approved":
+            continue
+        w_start = waiver.get("start_date")
+        w_end = waiver.get("end_date")
+        if not (isinstance(w_start, datetime) and isinstance(w_end, datetime)):
+            continue
+        if not (ensure_utc(w_start) <= start <= ensure_utc(w_end)):
+            continue
+        types = {t.lower() for t in (waiver.get("event_types") or ["pt", "lab"])}
+        if event_type and event_type not in types:
+            continue
+        return waiver
+    return None
 
 
 def load_cadet_flights(cadet: dict) -> list[dict]:
@@ -48,10 +81,12 @@ def cadet_attendance(
     records: list[dict],
     events: list[dict],
     waivers: list[dict],
+    standing_waivers: list[dict] | None = None,
 ) -> list[dict]:
     records = merge_attendance_records(records, key_fields=("event_id", "cadet_id"))
     event_map = {e["_id"]: e for e in events}
     waiver_map = {w["attendance_record_id"]: w for w in waivers}
+    standing = standing_waivers or []
 
     rows = []
     for record in records:
@@ -62,6 +97,10 @@ def cadet_attendance(
             continue
 
         waiver_status = (waiver.get("status") or "").lower() if waiver else None
+        if waiver_status is None and standing:
+            covering = _covering_standing_waiver(event, standing)
+            if covering is not None:
+                waiver_status = "approved"
         status = get_effective_attendance_status(
             record.get("status") or "—",
             waiver_status,

--- a/services/cadet_attendance.py
+++ b/services/cadet_attendance.py
@@ -31,9 +31,7 @@ def load_attendance_db(
     return records, events, waivers, standing_waivers
 
 
-def _covering_standing_waiver(
-    event: dict, standing_waivers: list[dict]
-) -> dict | None:
+def _covering_standing_waiver(event: dict, standing_waivers: list[dict]) -> dict | None:
     """Return the approved standing waiver that covers this event, if any."""
     start = event.get("start_date")
     if not isinstance(start, datetime):

--- a/services/events.py
+++ b/services/events.py
@@ -5,6 +5,7 @@ from zoneinfo import ZoneInfo, available_timezones
 from bson import ObjectId
 
 from utils.audit_log import log_data_change, serialize_doc_for_audit
+from utils.date_range import expand_event_dates
 from utils.db import get_db
 from utils.datetime_utils import ensure_utc
 
@@ -303,18 +304,9 @@ def preview_semester_schedule(
     skip_dates: list[date],
 ) -> list[dict]:
     """Return a list of events that would be created (no DB writes)."""
-    skip_set = set(skip_dates)
-    events = []
-    current = semester_start
-    while current <= semester_end:
-        day_name = current.strftime("%A")
-        if current not in skip_set:
-            if day_name in pt_days:
-                events.append({"date": current, "type": "PT", "day": day_name})
-            elif day_name in llab_days:
-                events.append({"date": current, "type": "LLAB", "day": day_name})
-        current += timedelta(days=1)
-    return events
+    return expand_event_dates(
+        semester_start, semester_end, pt_days, llab_days, skip_dates
+    )
 
 
 def archive_event(

--- a/services/waiver_review.py
+++ b/services/waiver_review.py
@@ -12,6 +12,7 @@ from utils.db_schema_crud import (
     get_all_waivers,
     get_attendance_record_by_id,
     get_cadet_by_id,
+    get_cadet_by_user_id,
     get_event_by_id,
     get_flight_by_id,
     get_user_by_id,
@@ -19,6 +20,7 @@ from utils.db_schema_crud import (
     update_waiver,
 )
 
+from services.waivers import distribute_excused_status, revert_excused_status
 from utils.audit_log import log_data_change
 from utils.names import format_full_name
 from utils.pagination import build_pagination_metadata, paginate_list
@@ -92,16 +94,47 @@ def _waiver_review_base_pipeline(
                     "as": "attendance_record",
                 }
             },
-            {"$unwind": "$attendance_record"},
+            {
+                "$unwind": {
+                    "path": "$attendance_record",
+                    "preserveNullAndEmptyArrays": True,
+                }
+            },
             {
                 "$lookup": {
                     "from": "cadets",
                     "localField": "attendance_record.cadet_id",
                     "foreignField": "_id",
-                    "as": "cadet",
+                    "as": "cadet_via_record",
                 }
             },
-            {"$unwind": "$cadet"},
+            {
+                "$unwind": {
+                    "path": "$cadet_via_record",
+                    "preserveNullAndEmptyArrays": True,
+                }
+            },
+            {
+                "$lookup": {
+                    "from": "cadets",
+                    "localField": "submitted_by_user_id",
+                    "foreignField": "user_id",
+                    "as": "cadet_via_submitter",
+                }
+            },
+            {
+                "$unwind": {
+                    "path": "$cadet_via_submitter",
+                    "preserveNullAndEmptyArrays": True,
+                }
+            },
+            {
+                "$addFields": {
+                    "cadet": {
+                        "$ifNull": ["$cadet_via_record", "$cadet_via_submitter"]
+                    }
+                }
+            },
             {
                 "$lookup": {
                     "from": "users",
@@ -203,6 +236,21 @@ def _waiver_review_base_pipeline(
     return pipeline
 
 
+def _standing_event_label(doc: dict) -> tuple[str, str, str]:
+    """Return (event_name, event_date, event_type) for a standing waiver row."""
+    types = doc.get("event_types") or ["pt", "lab"]
+    type_label = "/".join(t.upper() if t == "pt" else "LLAB" for t in types)
+    start = doc.get("start_date")
+    end = doc.get("end_date")
+    start_str = _fmt_date(start)
+    end_str = _fmt_date(end)
+    return (
+        f"Standing waiver ({type_label})",
+        f"{start_str} → {end_str}",
+        "standing",
+    )
+
+
 def _waiver_review_rows_from_docs(docs: list[dict]) -> list[dict]:
     rows: list[dict] = []
     for doc in docs:
@@ -217,6 +265,13 @@ def _waiver_review_rows_from_docs(docs: list[dict]) -> list[dict]:
             last = str(cadet.get("last_name", "") or "").strip()
             cadet_name = f"{first} {last}".strip() or "Unknown cadet"
 
+        if doc.get("is_standing"):
+            event_name, event_date, event_type = _standing_event_label(doc)
+        else:
+            event_name = str(event.get("event_name") or "Unknown event")
+            event_date = _fmt_date(event.get("start_date"))
+            event_type = (event.get("event_type") or "") or "unknown"
+
         rows.append(
             {
                 "waiver_id": doc.get("_id"),
@@ -227,10 +282,11 @@ def _waiver_review_rows_from_docs(docs: list[dict]) -> list[dict]:
                 "cadet_name": cadet_name,
                 "cadet_email": str(cadet_user.get("email") or cadet.get("email") or ""),
                 "flight_name": str(flight.get("name") or "Unassigned"),
-                "event_name": str(event.get("event_name") or "Unknown event"),
-                "event_date": _fmt_date(event.get("start_date")),
-                "event_type": (event.get("event_type") or "") or "unknown",
+                "event_name": event_name,
+                "event_date": event_date,
+                "event_type": event_type,
                 "cadre_only": bool(doc.get("cadre_only", False)),
+                "is_standing": bool(doc.get("is_standing", False)),
             }
         )
     return rows
@@ -276,6 +332,7 @@ def _fallback_waiver_review_rows(
                 "event_name": ctx["event_name"],
                 "event_date": ctx["event_date"],
                 "event_type": ctx["event_type"],
+                "is_standing": bool(waiver.get("is_standing", False)),
                 "cadre_only": ctx["cadre_only"],
             }
         )
@@ -358,11 +415,50 @@ def get_paginated_waiver_review_rows(
     return {**pagination, "items": _waiver_review_rows_from_docs(docs)}
 
 
+def _flight_name_for_cadet(cadet: dict | None) -> str:
+    if cadet is None:
+        return "Unassigned"
+    cadet_flight_id = cadet.get("flight_id")
+    if cadet_flight_id is None:
+        return "Unassigned"
+    flight = get_flight_by_id(cadet_flight_id)
+    return flight.get("name", "Unassigned") if flight else "Unassigned"
+
+
+def _standing_waiver_context(waiver: dict) -> dict | None:
+    submitter_id = waiver.get("submitted_by_user_id")
+    if submitter_id is None:
+        return None
+
+    cadet = get_cadet_by_user_id(submitter_id)
+    user = get_user_by_id(submitter_id) if submitter_id is not None else None
+
+    types = waiver.get("event_types") or ["pt", "lab"]
+    type_label = "/".join(t.upper() if t == "pt" else "LLAB" for t in types)
+    start_str = _fmt_date(waiver.get("start_date"))
+    end_str = _fmt_date(waiver.get("end_date"))
+
+    return {
+        "cadet_name": format_full_name(user, "Unknown cadet"),
+        "cadet_email": user.get("email") if user else "",
+        "flight_name": _flight_name_for_cadet(cadet),
+        "event_name": f"Standing waiver ({type_label})",
+        "event_date": f"{start_str} → {end_str}",
+        "event_type": "standing",
+        "waiver_type": waiver.get("waiver_type") or "non-medical",
+        "attachments": waiver.get("attachments") or [],
+        "cadre_only": bool(waiver.get("cadre_only", False)),
+    }
+
+
 def get_waiver_context(waiver: dict) -> dict | None:
     """
     For a single waiver, fetch and return all related data.
     Returns None if any required data is missing.
     """
+    if waiver.get("is_standing"):
+        return _standing_waiver_context(waiver)
+
     attendance_record_id = waiver.get("attendance_record_id")
     if attendance_record_id is None:
         return None
@@ -387,20 +483,12 @@ def get_waiver_context(waiver: dict) -> dict | None:
         if user_id is not None:
             user = get_user_by_id(user_id)
 
-    flight_name = "Unassigned"
-    if cadet is not None:
-        cadet_flight_id = cadet.get("flight_id")
-        if cadet_flight_id is not None:
-            flight = get_flight_by_id(cadet_flight_id)
-            if flight:
-                flight_name = flight.get("name", "Unassigned")
-
     cadet_name = format_full_name(user, "Unknown cadet")
 
     return {
         "cadet_name": cadet_name,
         "cadet_email": user.get("email") if user else "",
-        "flight_name": flight_name,
+        "flight_name": _flight_name_for_cadet(cadet),
         "event_name": event.get("event_name") if event else "Unknown event",
         "event_date": _fmt_date(event.get("start_date") if event else None),
         "event_type": (event.get("event_type") if event else "") or "unknown",
@@ -460,6 +548,13 @@ def submit_decision(
             "waiver_id": str(waiver_id),
         },
     )
+
+    if before_waiver is not None:
+        was_approved = (before_status or "").lower() == "approved"
+        if new_status == "approved" and not was_approved:
+            distribute_excused_status(before_waiver, approver_id)
+        elif new_status == "denied" and was_approved:
+            revert_excused_status(before_waiver, approver_id)
 
     if cadet_email:
         send_waiver_decision_email(

--- a/services/waiver_review.py
+++ b/services/waiver_review.py
@@ -130,9 +130,7 @@ def _waiver_review_base_pipeline(
             },
             {
                 "$addFields": {
-                    "cadet": {
-                        "$ifNull": ["$cadet_via_record", "$cadet_via_submitter"]
-                    }
+                    "cadet": {"$ifNull": ["$cadet_via_record", "$cadet_via_submitter"]}
                 }
             },
             {

--- a/services/waivers.py
+++ b/services/waivers.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 
 from bson import ObjectId
 
@@ -7,9 +7,10 @@ from utils.audit_log import log_attendance_modification
 from utils.date_range import expand_event_dates
 from utils.datetime_utils import ensure_utc
 from utils.db_schema_crud import (
+    bulk_upsert_attendance_status,
     create_waiver_approval,
-    get_attendance_record_by_event_cadet,
     get_attendance_record_by_id,
+    get_attendance_records_for_cadet_in_events,
     get_cadet_by_user_id,
     get_events_by_date_range,
     get_sickness_waivers_by_user,
@@ -18,6 +19,8 @@ from utils.db_schema_crud import (
     upsert_attendance_record,
     validate_waiver,
 )
+
+MAX_STANDING_WAIVER_WEEKS = 16
 
 COMMON_REASONS = [
     "Military Orders",
@@ -51,7 +54,11 @@ def is_first_sickness_waiver(user_id) -> bool:
 
 
 def apply_sickness_auto_approval(waiver_id, user_id) -> bool:
-    """Auto-approve a sickness waiver if it is the cadet's first. Returns True if approved."""
+    """Auto-approve a sickness waiver if it is the cadet's first. Returns True if approved.
+
+    On approval, also flips covered attendance records to excused so the
+    persisted state matches what cadre approval would produce.
+    """
     waiver = get_waiver_by_id(waiver_id)
     if not waiver:
         return False
@@ -72,6 +79,9 @@ def apply_sickness_auto_approval(waiver_id, user_id) -> bool:
         decision="approved",
         comments="Auto-approved: first sickness waiver.",
     )
+
+    approved_waiver = get_waiver_by_id(waiver_id) or {**waiver, "status": "approved"}
+    distribute_excused_status(approved_waiver, user_id)
     return True
 
 
@@ -238,9 +248,11 @@ def validate_standing_waiver(
     if end < start:
         return False, "End date must be on or after start date."
 
-    today = datetime.now(timezone.utc).date()
-    if start.year != today.year or end.year != today.year:
-        return False, "Standing waiver dates must be in the current year."
+    if (end - start) > timedelta(weeks=MAX_STANDING_WAIVER_WEEKS):
+        return (
+            False,
+            f"Standing waivers cannot exceed {MAX_STANDING_WAIVER_WEEKS} weeks.",
+        )
 
     covered = compute_standing_waiver_dates(start, end, event_types)
     if not covered:
@@ -411,7 +423,15 @@ def _resolve_standing_target(
     )
 
 
-def _distribute_standing(waiver: dict, actor_user_id: str | ObjectId) -> int:
+def _bulk_transition_standing(
+    waiver: dict,
+    actor_user_id: str | ObjectId,
+    *,
+    from_status: str,
+    to_status: str,
+    audit_reason: str,
+) -> int:
+    """Shared bulk path: fetch all records once, write all transitions once."""
     target = _resolve_standing_target(waiver)
     if target is None:
         return 0
@@ -419,43 +439,61 @@ def _distribute_standing(waiver: dict, actor_user_id: str | ObjectId) -> int:
     waiver_id = waiver["_id"]
 
     events = get_events_by_date_range(start, end, event_types=event_types)
-    updated = 0
-    for event in events:
-        event_id = ObjectId(event["_id"])
-        record = get_attendance_record_by_event_cadet(event_id, cadet_id)
-        if record is None:
-            continue
-        if _set_attendance_excused(
-            record=record,
+    if not events:
+        return 0
+
+    event_ids = [ObjectId(e["_id"]) for e in events]
+    records = get_attendance_records_for_cadet_in_events(event_ids, cadet_id)
+    transitions = [
+        r for r in records if (r.get("status") or "").lower() == from_status
+    ]
+    if not transitions:
+        return 0
+
+    bulk_upsert_attendance_status(
+        [
+            {
+                "event_id": ObjectId(r["event_id"]),
+                "cadet_id": cadet_id,
+                "status": to_status,
+                "recorded_by_user_id": actor_user_id,
+                "recorded_by_roles": ["system"],
+            }
+            for r in transitions
+        ]
+    )
+    for r in transitions:
+        log_attendance_modification(
+            event_id=ObjectId(r["event_id"]),
             cadet_id=cadet_id,
-            event_id=event_id,
-            actor_user_id=actor_user_id,
-            waiver_id=waiver_id,
-        ):
-            updated += 1
-    return updated
+            user_id=actor_user_id,
+            outcome="applied",
+            old_status=from_status,
+            new_status=to_status,
+            source=_DISTRIBUTE_AUDIT_SOURCE,
+            metadata={
+                "waiver_id": str(waiver_id),
+                "reason": audit_reason,
+            },
+        )
+    return len(transitions)
+
+
+def _distribute_standing(waiver: dict, actor_user_id: str | ObjectId) -> int:
+    return _bulk_transition_standing(
+        waiver,
+        actor_user_id,
+        from_status="absent",
+        to_status="excused",
+        audit_reason="waiver_approved",
+    )
 
 
 def _revert_standing(waiver: dict, actor_user_id: str | ObjectId) -> int:
-    target = _resolve_standing_target(waiver)
-    if target is None:
-        return 0
-    cadet_id, start, end, event_types = target
-    waiver_id = waiver["_id"]
-
-    events = get_events_by_date_range(start, end, event_types=event_types)
-    reverted = 0
-    for event in events:
-        event_id = ObjectId(event["_id"])
-        record = get_attendance_record_by_event_cadet(event_id, cadet_id)
-        if record is None:
-            continue
-        if _set_attendance_absent(
-            record=record,
-            cadet_id=cadet_id,
-            event_id=event_id,
-            actor_user_id=actor_user_id,
-            waiver_id=waiver_id,
-        ):
-            reverted += 1
-    return reverted
+    return _bulk_transition_standing(
+        waiver,
+        actor_user_id,
+        from_status="excused",
+        to_status="absent",
+        audit_reason="waiver_denied",
+    )

--- a/services/waivers.py
+++ b/services/waivers.py
@@ -1,10 +1,21 @@
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 
+from bson import ObjectId
+
+from services.event_config import get_event_config
+from utils.audit_log import log_attendance_modification
+from utils.date_range import expand_event_dates
+from utils.datetime_utils import ensure_utc
 from utils.db_schema_crud import (
     create_waiver_approval,
+    get_attendance_record_by_event_cadet,
+    get_attendance_record_by_id,
+    get_cadet_by_user_id,
+    get_events_by_date_range,
     get_sickness_waivers_by_user,
     get_waiver_by_id,
     update_waiver,
+    upsert_attendance_record,
     validate_waiver,
 )
 
@@ -178,3 +189,271 @@ def withdraw_waiver(waiver_id: str) -> bool:
     """Delete pending waiver. Returns True on success"""
     result = update_waiver(waiver_id, {"status": "withdrawn"})
     return bool(result and result.modified_count > 0)
+
+
+_DEFAULT_PT_DAYS = ["Monday", "Tuesday", "Thursday"]
+_DEFAULT_LLAB_DAYS = ["Friday"]
+_DISTRIBUTE_AUDIT_SOURCE = "attendance_modification"
+
+
+def _scheduled_days() -> tuple[list[str], list[str]]:
+    config = get_event_config() or {}
+    return (
+        config.get("pt_days", _DEFAULT_PT_DAYS),
+        config.get("llab_days", _DEFAULT_LLAB_DAYS),
+    )
+
+
+def _filter_days_by_event_types(
+    pt_days: list[str],
+    llab_days: list[str],
+    event_types: list[str] | None,
+) -> tuple[list[str], list[str]]:
+    types = {t.lower() for t in (event_types or ["pt", "lab"])}
+    return (pt_days if "pt" in types else [], llab_days if "lab" in types else [])
+
+
+def compute_standing_waiver_dates(
+    start: date,
+    end: date,
+    event_types: list[str] | None = None,
+) -> list[dict]:
+    """Return event-eligible dates a standing waiver would cover.
+
+    Uses the configured PT/LLAB days from event_config, optionally narrowed
+    by `event_types` (any of "pt", "lab"). Each entry has the same shape as
+    `expand_event_dates`: {"date", "type", "day"}.
+    """
+    pt_days, llab_days = _scheduled_days()
+    pt_days, llab_days = _filter_days_by_event_types(pt_days, llab_days, event_types)
+    return expand_event_dates(start, end, pt_days, llab_days)
+
+
+def validate_standing_waiver(
+    start: date,
+    end: date,
+    event_types: list[str] | None = None,
+) -> tuple[bool, str]:
+    """Return (is_valid, why) for a proposed standing waiver date range."""
+    if end < start:
+        return False, "End date must be on or after start date."
+
+    today = datetime.now(timezone.utc).date()
+    if start.year != today.year or end.year != today.year:
+        return False, "Standing waiver dates must be in the current year."
+
+    covered = compute_standing_waiver_dates(start, end, event_types)
+    if not covered:
+        return False, "Date range does not cover any PT or LLAB days."
+
+    return True, ""
+
+
+def _waiver_event_type_filter(waiver: dict) -> list[str]:
+    types = waiver.get("event_types") or ["pt", "lab"]
+    return [str(t).lower() for t in types]
+
+
+def _set_attendance_excused(
+    *,
+    record: dict,
+    cadet_id: ObjectId,
+    event_id: ObjectId,
+    actor_user_id: str | ObjectId,
+    waiver_id: str | ObjectId,
+) -> bool:
+    """Flip an absent record to excused. Returns True if changed."""
+    current_status = (record.get("status") or "").lower()
+    if current_status != "absent":
+        return False
+
+    upsert_attendance_record(
+        event_id=event_id,
+        cadet_id=cadet_id,
+        status="excused",
+        recorded_by_user_id=actor_user_id,
+        recorded_by_roles=["system"],
+    )
+    log_attendance_modification(
+        event_id=event_id,
+        cadet_id=cadet_id,
+        user_id=actor_user_id,
+        outcome="applied",
+        old_status="absent",
+        new_status="excused",
+        source=_DISTRIBUTE_AUDIT_SOURCE,
+        metadata={
+            "waiver_id": str(waiver_id),
+            "reason": "waiver_approved",
+        },
+    )
+    return True
+
+
+def _set_attendance_absent(
+    *,
+    record: dict,
+    cadet_id: ObjectId,
+    event_id: ObjectId,
+    actor_user_id: str | ObjectId,
+    waiver_id: str | ObjectId,
+) -> bool:
+    """Revert an excused record back to absent. Returns True if changed."""
+    current_status = (record.get("status") or "").lower()
+    if current_status != "excused":
+        return False
+
+    upsert_attendance_record(
+        event_id=event_id,
+        cadet_id=cadet_id,
+        status="absent",
+        recorded_by_user_id=actor_user_id,
+        recorded_by_roles=["system"],
+    )
+    log_attendance_modification(
+        event_id=event_id,
+        cadet_id=cadet_id,
+        user_id=actor_user_id,
+        outcome="applied",
+        old_status="excused",
+        new_status="absent",
+        source=_DISTRIBUTE_AUDIT_SOURCE,
+        metadata={
+            "waiver_id": str(waiver_id),
+            "reason": "waiver_denied",
+        },
+    )
+    return True
+
+
+def distribute_excused_status(
+    waiver: dict,
+    actor_user_id: str | ObjectId,
+) -> int:
+    """Apply 'excused' to attendance records covered by an approved waiver.
+
+    Singular waivers update a single record. Standing waivers find every
+    PT/LLAB attendance record for the cadet inside [start_date, end_date]
+    and mark each absent record as excused. Returns the number of records
+    actually updated.
+    """
+    waiver_id = waiver.get("_id")
+    if waiver_id is None:
+        return 0
+
+    if waiver.get("is_standing"):
+        return _distribute_standing(waiver, actor_user_id)
+
+    record_id = waiver.get("attendance_record_id")
+    if record_id is None:
+        return 0
+    record = get_attendance_record_by_id(record_id)
+    if record is None:
+        return 0
+    changed = _set_attendance_excused(
+        record=record,
+        cadet_id=ObjectId(record["cadet_id"]),
+        event_id=ObjectId(record["event_id"]),
+        actor_user_id=actor_user_id,
+        waiver_id=waiver_id,
+    )
+    return 1 if changed else 0
+
+
+def revert_excused_status(
+    waiver: dict,
+    actor_user_id: str | ObjectId,
+) -> int:
+    """Undo `distribute_excused_status` for a waiver: excused -> absent."""
+    waiver_id = waiver.get("_id")
+    if waiver_id is None:
+        return 0
+
+    if waiver.get("is_standing"):
+        return _revert_standing(waiver, actor_user_id)
+
+    record_id = waiver.get("attendance_record_id")
+    if record_id is None:
+        return 0
+    record = get_attendance_record_by_id(record_id)
+    if record is None:
+        return 0
+    changed = _set_attendance_absent(
+        record=record,
+        cadet_id=ObjectId(record["cadet_id"]),
+        event_id=ObjectId(record["event_id"]),
+        actor_user_id=actor_user_id,
+        waiver_id=waiver_id,
+    )
+    return 1 if changed else 0
+
+
+def _resolve_standing_target(
+    waiver: dict,
+) -> tuple[ObjectId, datetime, datetime, list[str]] | None:
+    submitter_id = waiver.get("submitted_by_user_id")
+    start = waiver.get("start_date")
+    end = waiver.get("end_date")
+    if submitter_id is None or not isinstance(start, datetime) or not isinstance(
+        end, datetime
+    ):
+        return None
+    cadet = get_cadet_by_user_id(submitter_id)
+    if cadet is None:
+        return None
+    return (
+        ObjectId(cadet["_id"]),
+        ensure_utc(start),
+        ensure_utc(end),
+        _waiver_event_type_filter(waiver),
+    )
+
+
+def _distribute_standing(waiver: dict, actor_user_id: str | ObjectId) -> int:
+    target = _resolve_standing_target(waiver)
+    if target is None:
+        return 0
+    cadet_id, start, end, event_types = target
+    waiver_id = waiver["_id"]
+
+    events = get_events_by_date_range(start, end, event_types=event_types)
+    updated = 0
+    for event in events:
+        event_id = ObjectId(event["_id"])
+        record = get_attendance_record_by_event_cadet(event_id, cadet_id)
+        if record is None:
+            continue
+        if _set_attendance_excused(
+            record=record,
+            cadet_id=cadet_id,
+            event_id=event_id,
+            actor_user_id=actor_user_id,
+            waiver_id=waiver_id,
+        ):
+            updated += 1
+    return updated
+
+
+def _revert_standing(waiver: dict, actor_user_id: str | ObjectId) -> int:
+    target = _resolve_standing_target(waiver)
+    if target is None:
+        return 0
+    cadet_id, start, end, event_types = target
+    waiver_id = waiver["_id"]
+
+    events = get_events_by_date_range(start, end, event_types=event_types)
+    reverted = 0
+    for event in events:
+        event_id = ObjectId(event["_id"])
+        record = get_attendance_record_by_event_cadet(event_id, cadet_id)
+        if record is None:
+            continue
+        if _set_attendance_absent(
+            record=record,
+            cadet_id=cadet_id,
+            event_id=event_id,
+            actor_user_id=actor_user_id,
+            waiver_id=waiver_id,
+        ):
+            reverted += 1
+    return reverted

--- a/services/waivers.py
+++ b/services/waivers.py
@@ -394,8 +394,10 @@ def _resolve_standing_target(
     submitter_id = waiver.get("submitted_by_user_id")
     start = waiver.get("start_date")
     end = waiver.get("end_date")
-    if submitter_id is None or not isinstance(start, datetime) or not isinstance(
-        end, datetime
+    if (
+        submitter_id is None
+        or not isinstance(start, datetime)
+        or not isinstance(end, datetime)
     ):
         return None
     cadet = get_cadet_by_user_id(submitter_id)

--- a/tests/test_cadet_attendance.py
+++ b/tests/test_cadet_attendance.py
@@ -307,7 +307,9 @@ def test_get_cadet_flight_label_flights_empty():
 # ---------------- standing waiver coverage ------------------
 
 
-def _standing_waiver(start_offset: int, end_offset: int, event_types=None, status="approved"):
+def _standing_waiver(
+    start_offset: int, end_offset: int, event_types=None, status="approved"
+):
     return {
         "_id": "ws1",
         "is_standing": True,
@@ -321,7 +323,12 @@ def _standing_waiver(start_offset: int, end_offset: int, event_types=None, statu
 def test_standing_waiver_marks_record_as_excused():
     records = [{"_id": "rec1", "event_id": "evt1", "status": "absent"}]
     events = [
-        {"_id": "evt1", "event_name": "LLAB Week 2", "event_type": "lab", "start_date": _dt(2)}
+        {
+            "_id": "evt1",
+            "event_name": "LLAB Week 2",
+            "event_type": "lab",
+            "start_date": _dt(2),
+        }
     ]
     standing = [_standing_waiver(start_offset=5, end_offset=0)]
 

--- a/tests/test_cadet_attendance.py
+++ b/tests/test_cadet_attendance.py
@@ -302,3 +302,79 @@ def test_get_cadet_flight_label_flights_empty():
     cadet = {"flight_id": "flight1"}
     flights = []
     assert get_cadet_flight_label(cadet, flights) == "—"
+
+
+# ---------------- standing waiver coverage ------------------
+
+
+def _standing_waiver(start_offset: int, end_offset: int, event_types=None, status="approved"):
+    return {
+        "_id": "ws1",
+        "is_standing": True,
+        "status": status,
+        "start_date": _dt(start_offset),
+        "end_date": _dt(end_offset),
+        "event_types": event_types or ["pt", "lab"],
+    }
+
+
+def test_standing_waiver_marks_record_as_excused():
+    records = [{"_id": "rec1", "event_id": "evt1", "status": "absent"}]
+    events = [
+        {"_id": "evt1", "event_name": "LLAB Week 2", "event_type": "lab", "start_date": _dt(2)}
+    ]
+    standing = [_standing_waiver(start_offset=5, end_offset=0)]
+
+    rows = cadet_attendance(records, events, [], standing_waivers=standing)
+
+    assert rows[0]["waiver_status"] == "approved"
+    assert rows[0]["status"] == "waived"
+
+
+def test_standing_waiver_outside_range_does_not_apply():
+    records = [{"_id": "rec1", "event_id": "evt1", "status": "absent"}]
+    events = [
+        {"_id": "evt1", "event_name": "PT", "event_type": "pt", "start_date": _dt(20)}
+    ]
+    standing = [_standing_waiver(start_offset=5, end_offset=0)]
+
+    rows = cadet_attendance(records, events, [], standing_waivers=standing)
+
+    assert rows[0]["waiver_status"] is None
+
+
+def test_standing_waiver_event_type_mismatch_does_not_apply():
+    records = [{"_id": "rec1", "event_id": "evt1", "status": "absent"}]
+    events = [
+        {"_id": "evt1", "event_name": "PT", "event_type": "pt", "start_date": _dt(2)}
+    ]
+    standing = [_standing_waiver(start_offset=5, end_offset=0, event_types=["lab"])]
+
+    rows = cadet_attendance(records, events, [], standing_waivers=standing)
+
+    assert rows[0]["waiver_status"] is None
+
+
+def test_pending_standing_waiver_does_not_excuse():
+    records = [{"_id": "rec1", "event_id": "evt1", "status": "absent"}]
+    events = [
+        {"_id": "evt1", "event_name": "PT", "event_type": "pt", "start_date": _dt(2)}
+    ]
+    standing = [_standing_waiver(start_offset=5, end_offset=0, status="pending")]
+
+    rows = cadet_attendance(records, events, [], standing_waivers=standing)
+
+    assert rows[0]["waiver_status"] is None
+
+
+def test_singular_waiver_takes_precedence_over_standing():
+    records = [{"_id": "rec1", "event_id": "evt1", "status": "absent"}]
+    events = [
+        {"_id": "evt1", "event_name": "PT", "event_type": "pt", "start_date": _dt(2)}
+    ]
+    waivers = [{"_id": "w1", "attendance_record_id": "rec1", "status": "denied"}]
+    standing = [_standing_waiver(start_offset=5, end_offset=0)]
+
+    rows = cadet_attendance(records, events, waivers, standing_waivers=standing)
+
+    assert rows[0]["waiver_status"] == "denied"

--- a/tests/test_date_range.py
+++ b/tests/test_date_range.py
@@ -1,0 +1,154 @@
+from datetime import date, timedelta
+
+from utils.date_range import expand_event_dates, parse_streamlit_date_range
+
+
+# =============================================================================
+# expand_event_dates
+# Week used in tests: Apr 27 (Mon) – May 3 (Sun) 2026
+# Default config: PT = Mon/Tue/Thu, LLAB = Fri
+# =============================================================================
+
+_PT_DAYS = ["Monday", "Tuesday", "Thursday"]
+_LLAB_DAYS = ["Friday"]
+
+_MON = date(2026, 4, 27)
+_TUE = date(2026, 4, 28)
+_WED = date(2026, 4, 29)
+_THU = date(2026, 4, 30)
+_FRI = date(2026, 5, 1)
+_SAT = date(2026, 5, 2)
+_SUN = date(2026, 5, 3)
+
+
+def test_returns_pt_event_on_monday() -> None:
+    result = expand_event_dates(_MON, _MON, _PT_DAYS, _LLAB_DAYS)
+    assert len(result) == 1
+    assert result[0]["type"] == "PT"
+
+
+def test_returns_llab_event_on_friday() -> None:
+    result = expand_event_dates(_FRI, _FRI, _PT_DAYS, _LLAB_DAYS)
+    assert len(result) == 1
+    assert result[0]["type"] == "LLAB"
+
+
+def test_skips_wednesday() -> None:
+    assert expand_event_dates(_WED, _WED, _PT_DAYS, _LLAB_DAYS) == []
+
+
+def test_skips_weekend() -> None:
+    assert expand_event_dates(_SAT, _SAT, _PT_DAYS, _LLAB_DAYS) == []
+    assert expand_event_dates(_SUN, _SUN, _PT_DAYS, _LLAB_DAYS) == []
+
+
+def test_full_week_gives_four_events() -> None:
+    result = expand_event_dates(_MON, _SUN, _PT_DAYS, _LLAB_DAYS)
+    assert len(result) == 4
+    pt = [e for e in result if e["type"] == "PT"]
+    llab = [e for e in result if e["type"] == "LLAB"]
+    assert len(pt) == 3
+    assert len(llab) == 1
+
+
+def test_skip_dates_are_excluded() -> None:
+    result = expand_event_dates(_MON, _SUN, _PT_DAYS, _LLAB_DAYS, skip=[_MON, _FRI])
+    assert all(e["date"] not in {_MON, _FRI} for e in result)
+    assert len(result) == 2
+
+
+def test_end_before_start_returns_empty() -> None:
+    assert expand_event_dates(_FRI, _MON, _PT_DAYS, _LLAB_DAYS) == []
+
+
+def test_pt_only_when_llab_days_empty() -> None:
+    result = expand_event_dates(_MON, _SUN, _PT_DAYS, [])
+    assert all(e["type"] == "PT" for e in result)
+    assert len(result) == 3
+
+
+def test_llab_only_when_pt_days_empty() -> None:
+    result = expand_event_dates(_MON, _SUN, [], _LLAB_DAYS)
+    assert all(e["type"] == "LLAB" for e in result)
+    assert len(result) == 1
+
+
+def test_results_chronologically_ordered() -> None:
+    result = expand_event_dates(_MON, _SUN, _PT_DAYS, _LLAB_DAYS)
+    dates = [e["date"] for e in result]
+    assert dates == sorted(dates)
+
+
+def test_event_has_day_name() -> None:
+    result = expand_event_dates(_MON, _MON, _PT_DAYS, _LLAB_DAYS)
+    assert result[0]["day"] == "Monday"
+
+
+# =============================================================================
+# parse_streamlit_date_range
+# =============================================================================
+
+_DEFAULT_START = date(2026, 1, 1)
+_DEFAULT_END = date(2026, 1, 31)
+
+
+def test_parses_complete_tuple() -> None:
+    start, end, complete = parse_streamlit_date_range(
+        (_MON, _FRI), _DEFAULT_START, _DEFAULT_END
+    )
+    assert (start, end, complete) == (_MON, _FRI, True)
+
+
+def test_parses_complete_list() -> None:
+    start, end, complete = parse_streamlit_date_range(
+        [_MON, _FRI], _DEFAULT_START, _DEFAULT_END
+    )
+    assert (start, end, complete) == (_MON, _FRI, True)
+
+
+def test_swaps_reversed_tuple() -> None:
+    start, end, complete = parse_streamlit_date_range(
+        (_FRI, _MON), _DEFAULT_START, _DEFAULT_END
+    )
+    assert start == _MON
+    assert end == _FRI
+    assert complete is True
+
+
+def test_partial_tuple_returns_incomplete() -> None:
+    start, end, complete = parse_streamlit_date_range(
+        (_MON,), _DEFAULT_START, _DEFAULT_END
+    )
+    assert start == _MON
+    assert end == _DEFAULT_END
+    assert complete is False
+
+
+def test_bare_date_returns_incomplete() -> None:
+    start, end, complete = parse_streamlit_date_range(
+        _MON, _DEFAULT_START, _DEFAULT_END
+    )
+    assert start == _MON
+    assert end == _DEFAULT_END
+    assert complete is False
+
+
+def test_none_returns_defaults_incomplete() -> None:
+    start, end, complete = parse_streamlit_date_range(
+        None, _DEFAULT_START, _DEFAULT_END
+    )
+    assert (start, end, complete) == (_DEFAULT_START, _DEFAULT_END, False)
+
+
+def test_empty_tuple_returns_defaults_incomplete() -> None:
+    start, end, complete = parse_streamlit_date_range(
+        (), _DEFAULT_START, _DEFAULT_END
+    )
+    assert (start, end, complete) == (_DEFAULT_START, _DEFAULT_END, False)
+
+
+def test_two_week_range_gives_eight_events() -> None:
+    result = expand_event_dates(
+        _MON, _MON + timedelta(days=13), _PT_DAYS, _LLAB_DAYS
+    )
+    assert len(result) == 8

--- a/tests/test_date_range.py
+++ b/tests/test_date_range.py
@@ -141,14 +141,10 @@ def test_none_returns_defaults_incomplete() -> None:
 
 
 def test_empty_tuple_returns_defaults_incomplete() -> None:
-    start, end, complete = parse_streamlit_date_range(
-        (), _DEFAULT_START, _DEFAULT_END
-    )
+    start, end, complete = parse_streamlit_date_range((), _DEFAULT_START, _DEFAULT_END)
     assert (start, end, complete) == (_DEFAULT_START, _DEFAULT_END, False)
 
 
 def test_two_week_range_gives_eight_events() -> None:
-    result = expand_event_dates(
-        _MON, _MON + timedelta(days=13), _PT_DAYS, _LLAB_DAYS
-    )
+    result = expand_event_dates(_MON, _MON + timedelta(days=13), _PT_DAYS, _LLAB_DAYS)
     assert len(result) == 8

--- a/tests/test_db_schema_crud_batch.py
+++ b/tests/test_db_schema_crud_batch.py
@@ -191,9 +191,7 @@ class TestGetCadetsByUserIdsMap:
 
 class TestGetCadetAbsenceStats:
     @patch("utils.db_schema_crud.get_collection")
-    def test_pipeline_excludes_approved_waivers_from_absence_totals(
-        self, mock_get_col
-    ):
+    def test_pipeline_excludes_approved_waivers_from_absence_totals(self, mock_get_col):
         mock_col = MagicMock()
         mock_get_col.return_value = mock_col
         mock_col.aggregate.return_value = []

--- a/tests/test_waiver_flow.py
+++ b/tests/test_waiver_flow.py
@@ -154,6 +154,7 @@ def test_sickness_first_waiver_auto_approved():
         ),
         patch("services.waivers.update_waiver") as mock_update,
         patch("services.waivers.create_waiver_approval") as mock_approval,
+        patch("services.waivers.distribute_excused_status"),
     ):
         auto_approved = apply_sickness_auto_approval("w1", "user1")
 

--- a/tests/test_waiver_review.py
+++ b/tests/test_waiver_review.py
@@ -213,6 +213,42 @@ def test_get_waiver_context_returns_none_if_no_record_id():
     assert result is None
 
 
+def test_get_waiver_context_returns_standing_waiver_context():
+    standing = {
+        "_id": "w_standing",
+        "is_standing": True,
+        "submitted_by_user_id": "user1",
+        "start_date": datetime(2026, 4, 27, tzinfo=timezone.utc),
+        "end_date": datetime(2026, 5, 3, tzinfo=timezone.utc),
+        "event_types": ["pt", "lab"],
+        "waiver_type": "non-medical",
+        "attachments": [],
+    }
+    with (
+        patch("services.waiver_review.get_cadet_by_user_id", return_value=CADET),
+        patch("services.waiver_review.get_user_by_id", return_value=USER),
+        patch("services.waiver_review.get_flight_by_id", return_value=FLIGHT),
+    ):
+        result = get_waiver_context(standing)
+    assert result is not None
+    assert result["cadet_name"] == "Tyler Brooks"
+    assert result["flight_name"] == "Alpha Flight"
+    assert result["event_type"] == "standing"
+    assert "Standing waiver" in result["event_name"]
+    assert "→" in result["event_date"]
+
+
+def test_get_waiver_context_standing_returns_none_when_submitter_missing():
+    standing = {
+        "_id": "w_standing",
+        "is_standing": True,
+        "start_date": datetime(2026, 4, 27, tzinfo=timezone.utc),
+        "end_date": datetime(2026, 5, 3, tzinfo=timezone.utc),
+    }
+    result = get_waiver_context(standing)
+    assert result is None
+
+
 def test_get_waiver_context_returns_none_if_record_missing():
     with patch("services.waiver_review.get_attendance_record_by_id", return_value=None):
         result = get_waiver_context(WAIVER)
@@ -344,6 +380,97 @@ def test_submit_decision_skips_email_if_no_cadet_email():
     ):
         submit_decision("w1", "approver1", "Approve", "", "", "PT", "2026-03-01")
         mock_email.assert_not_called()
+
+
+def test_submit_decision_approve_distributes_excused():
+    pending_waiver = {"_id": "w1", "status": "pending"}
+    with (
+        patch(
+            "services.waiver_review.get_waiver_by_id", return_value=pending_waiver
+        ),
+        patch("services.waiver_review.update_waiver", return_value=True),
+        patch("services.waiver_review.create_waiver_approval", return_value=True),
+        patch("services.waiver_review.send_waiver_decision_email"),
+        patch(
+            "services.waiver_review.distribute_excused_status", return_value=1
+        ) as mock_distribute,
+        patch("services.waiver_review.revert_excused_status") as mock_revert,
+    ):
+        submit_decision(
+            "w1", "approver1", "Approve", "", "tyler@test.com", "PT", "2026-03-01"
+        )
+
+    mock_distribute.assert_called_once()
+    assert mock_distribute.call_args[0][0] is pending_waiver
+    mock_revert.assert_not_called()
+
+
+def test_submit_decision_deny_does_not_distribute_when_was_pending():
+    pending_waiver = {"_id": "w1", "status": "pending"}
+    with (
+        patch(
+            "services.waiver_review.get_waiver_by_id", return_value=pending_waiver
+        ),
+        patch("services.waiver_review.update_waiver", return_value=True),
+        patch("services.waiver_review.create_waiver_approval", return_value=True),
+        patch("services.waiver_review.send_waiver_decision_email"),
+        patch(
+            "services.waiver_review.distribute_excused_status"
+        ) as mock_distribute,
+        patch("services.waiver_review.revert_excused_status") as mock_revert,
+    ):
+        submit_decision(
+            "w1", "approver1", "Deny", "x", "tyler@test.com", "PT", "2026-03-01"
+        )
+
+    mock_distribute.assert_not_called()
+    mock_revert.assert_not_called()
+
+
+def test_submit_decision_deny_reverts_when_previously_approved():
+    approved_waiver = {"_id": "w1", "status": "approved"}
+    with (
+        patch(
+            "services.waiver_review.get_waiver_by_id", return_value=approved_waiver
+        ),
+        patch("services.waiver_review.update_waiver", return_value=True),
+        patch("services.waiver_review.create_waiver_approval", return_value=True),
+        patch("services.waiver_review.send_waiver_decision_email"),
+        patch(
+            "services.waiver_review.distribute_excused_status"
+        ) as mock_distribute,
+        patch(
+            "services.waiver_review.revert_excused_status", return_value=1
+        ) as mock_revert,
+    ):
+        submit_decision(
+            "w1", "approver1", "Deny", "x", "tyler@test.com", "PT", "2026-03-01"
+        )
+
+    mock_revert.assert_called_once()
+    mock_distribute.assert_not_called()
+
+
+def test_submit_decision_approve_skips_distribute_when_already_approved():
+    approved_waiver = {"_id": "w1", "status": "approved"}
+    with (
+        patch(
+            "services.waiver_review.get_waiver_by_id", return_value=approved_waiver
+        ),
+        patch("services.waiver_review.update_waiver", return_value=True),
+        patch("services.waiver_review.create_waiver_approval", return_value=True),
+        patch("services.waiver_review.send_waiver_decision_email"),
+        patch(
+            "services.waiver_review.distribute_excused_status"
+        ) as mock_distribute,
+        patch("services.waiver_review.revert_excused_status") as mock_revert,
+    ):
+        submit_decision(
+            "w1", "approver1", "Approve", "", "tyler@test.com", "PT", "2026-03-01"
+        )
+
+    mock_distribute.assert_not_called()
+    mock_revert.assert_not_called()
 
 
 # -------------------test get_waiver_export_df ------------------------------------

--- a/tests/test_waiver_review.py
+++ b/tests/test_waiver_review.py
@@ -385,9 +385,7 @@ def test_submit_decision_skips_email_if_no_cadet_email():
 def test_submit_decision_approve_distributes_excused():
     pending_waiver = {"_id": "w1", "status": "pending"}
     with (
-        patch(
-            "services.waiver_review.get_waiver_by_id", return_value=pending_waiver
-        ),
+        patch("services.waiver_review.get_waiver_by_id", return_value=pending_waiver),
         patch("services.waiver_review.update_waiver", return_value=True),
         patch("services.waiver_review.create_waiver_approval", return_value=True),
         patch("services.waiver_review.send_waiver_decision_email"),
@@ -408,15 +406,11 @@ def test_submit_decision_approve_distributes_excused():
 def test_submit_decision_deny_does_not_distribute_when_was_pending():
     pending_waiver = {"_id": "w1", "status": "pending"}
     with (
-        patch(
-            "services.waiver_review.get_waiver_by_id", return_value=pending_waiver
-        ),
+        patch("services.waiver_review.get_waiver_by_id", return_value=pending_waiver),
         patch("services.waiver_review.update_waiver", return_value=True),
         patch("services.waiver_review.create_waiver_approval", return_value=True),
         patch("services.waiver_review.send_waiver_decision_email"),
-        patch(
-            "services.waiver_review.distribute_excused_status"
-        ) as mock_distribute,
+        patch("services.waiver_review.distribute_excused_status") as mock_distribute,
         patch("services.waiver_review.revert_excused_status") as mock_revert,
     ):
         submit_decision(
@@ -430,15 +424,11 @@ def test_submit_decision_deny_does_not_distribute_when_was_pending():
 def test_submit_decision_deny_reverts_when_previously_approved():
     approved_waiver = {"_id": "w1", "status": "approved"}
     with (
-        patch(
-            "services.waiver_review.get_waiver_by_id", return_value=approved_waiver
-        ),
+        patch("services.waiver_review.get_waiver_by_id", return_value=approved_waiver),
         patch("services.waiver_review.update_waiver", return_value=True),
         patch("services.waiver_review.create_waiver_approval", return_value=True),
         patch("services.waiver_review.send_waiver_decision_email"),
-        patch(
-            "services.waiver_review.distribute_excused_status"
-        ) as mock_distribute,
+        patch("services.waiver_review.distribute_excused_status") as mock_distribute,
         patch(
             "services.waiver_review.revert_excused_status", return_value=1
         ) as mock_revert,
@@ -454,15 +444,11 @@ def test_submit_decision_deny_reverts_when_previously_approved():
 def test_submit_decision_approve_skips_distribute_when_already_approved():
     approved_waiver = {"_id": "w1", "status": "approved"}
     with (
-        patch(
-            "services.waiver_review.get_waiver_by_id", return_value=approved_waiver
-        ),
+        patch("services.waiver_review.get_waiver_by_id", return_value=approved_waiver),
         patch("services.waiver_review.update_waiver", return_value=True),
         patch("services.waiver_review.create_waiver_approval", return_value=True),
         patch("services.waiver_review.send_waiver_decision_email"),
-        patch(
-            "services.waiver_review.distribute_excused_status"
-        ) as mock_distribute,
+        patch("services.waiver_review.distribute_excused_status") as mock_distribute,
         patch("services.waiver_review.revert_excused_status") as mock_revert,
     ):
         submit_decision(

--- a/tests/test_waivers.py
+++ b/tests/test_waivers.py
@@ -583,9 +583,7 @@ def test_distribute_singular_flips_absent_to_excused():
     }
 
     with (
-        patch(
-            "services.waivers.get_attendance_record_by_id", return_value=record
-        ),
+        patch("services.waivers.get_attendance_record_by_id", return_value=record),
         patch("services.waivers.upsert_attendance_record") as mock_upsert,
         patch("services.waivers.log_attendance_modification") as mock_log,
     ):
@@ -610,9 +608,7 @@ def test_distribute_singular_skips_present_record():
     }
 
     with (
-        patch(
-            "services.waivers.get_attendance_record_by_id", return_value=record
-        ),
+        patch("services.waivers.get_attendance_record_by_id", return_value=record),
         patch("services.waivers.upsert_attendance_record") as mock_upsert,
         patch("services.waivers.log_attendance_modification") as mock_log,
     ):
@@ -772,9 +768,7 @@ def test_revert_singular_flips_excused_back_to_absent():
     }
 
     with (
-        patch(
-            "services.waivers.get_attendance_record_by_id", return_value=record
-        ),
+        patch("services.waivers.get_attendance_record_by_id", return_value=record),
         patch("services.waivers.upsert_attendance_record") as mock_upsert,
         patch("services.waivers.log_attendance_modification"),
     ):
@@ -798,9 +792,7 @@ def test_revert_singular_leaves_present_alone():
     }
 
     with (
-        patch(
-            "services.waivers.get_attendance_record_by_id", return_value=record
-        ),
+        patch("services.waivers.get_attendance_record_by_id", return_value=record),
         patch("services.waivers.upsert_attendance_record") as mock_upsert,
     ):
         n = revert_excused_status(waiver, ObjectId("d" * 24))

--- a/tests/test_waivers.py
+++ b/tests/test_waivers.py
@@ -416,12 +416,50 @@ def test_apply_sickness_auto_approval_approves_first():
         ),
         patch("services.waivers.update_waiver") as mock_update,
         patch("services.waivers.create_waiver_approval") as mock_approval,
+        patch("services.waivers.distribute_excused_status"),
     ):
         result = apply_sickness_auto_approval("w1", "user1")
         assert result is True
         mock_update.assert_called_once()
         mock_approval.assert_called_once()
         assert mock_update.call_args[0][1]["status"] == "approved"
+
+
+def test_apply_sickness_auto_approval_distributes_excused():
+    waiver = {"_id": "w1", "waiver_type": "sickness", "status": "pending"}
+    approved = {**waiver, "status": "approved"}
+    with (
+        patch(
+            "services.waivers.get_waiver_by_id",
+            side_effect=[waiver, approved],
+        ),
+        patch(
+            "services.waivers.get_sickness_waivers_by_user",
+            return_value=[{"_id": "w1"}],
+        ),
+        patch("services.waivers.update_waiver"),
+        patch("services.waivers.create_waiver_approval"),
+        patch("services.waivers.distribute_excused_status") as mock_distribute,
+    ):
+        apply_sickness_auto_approval("w1", "user1")
+
+    mock_distribute.assert_called_once_with(approved, "user1")
+
+
+def test_apply_sickness_auto_approval_does_not_distribute_when_skipped():
+    waiver = {"_id": "w1", "waiver_type": "sickness", "status": "pending"}
+    with (
+        patch("services.waivers.get_waiver_by_id", return_value=waiver),
+        patch(
+            "services.waivers.get_sickness_waivers_by_user",
+            return_value=[{"_id": "w1"}, {"_id": "w2"}],
+        ),
+        patch("services.waivers.distribute_excused_status") as mock_distribute,
+    ):
+        result = apply_sickness_auto_approval("w1", "user1")
+
+    assert result is False
+    mock_distribute.assert_not_called()
 
 
 def test_apply_sickness_auto_approval_skips_if_prior_sickness_exists():
@@ -469,6 +507,7 @@ def test_apply_sickness_auto_approval_comment_mentions_auto():
         ),
         patch("services.waivers.update_waiver"),
         patch("services.waivers.create_waiver_approval") as mock_approval,
+        patch("services.waivers.distribute_excused_status"),
     ):
         apply_sickness_auto_approval("w1", "user1")
         comments = mock_approval.call_args[1]["comments"]
@@ -522,18 +561,18 @@ def test_validate_standing_rejects_end_before_start():
     assert "End date" in why
 
 
-def test_validate_standing_rejects_cross_year():
-    with (
-        _patched_event_config(),
-        patch(
-            "services.waivers.datetime",
-            wraps=datetime,
-        ) as mock_dt,
-    ):
-        mock_dt.now.return_value = datetime(2026, 6, 1, tzinfo=timezone.utc)
-        ok, why = validate_standing_waiver(date(2025, 12, 1), date(2025, 12, 7))
+def test_validate_standing_accepts_cross_year_range():
+    with _patched_event_config():
+        ok, why = validate_standing_waiver(date(2026, 12, 28), date(2027, 1, 5))
+    assert ok is True
+    assert why == ""
+
+
+def test_validate_standing_rejects_range_exceeding_max_weeks():
+    with _patched_event_config():
+        ok, why = validate_standing_waiver(date(2026, 1, 1), date(2026, 6, 1))
     assert ok is False
-    assert "current year" in why
+    assert "weeks" in why.lower()
 
 
 def test_validate_standing_rejects_empty_range_with_no_eligible_days():
@@ -675,18 +714,63 @@ def test_distribute_standing_excuses_all_absent_records_in_range():
         patch(
             "services.waivers.get_events_by_date_range",
             return_value=[event_a, event_b],
-        ),
+        ) as mock_events,
         patch(
-            "services.waivers.get_attendance_record_by_event_cadet",
-            side_effect=[record_a, record_b],
-        ),
-        patch("services.waivers.upsert_attendance_record") as mock_upsert,
-        patch("services.waivers.log_attendance_modification"),
+            "services.waivers.get_attendance_records_for_cadet_in_events",
+            return_value=[record_a, record_b],
+        ) as mock_fetch,
+        patch("services.waivers.bulk_upsert_attendance_status") as mock_bulk,
+        patch("services.waivers.log_attendance_modification") as mock_log,
     ):
         n = distribute_excused_status(_standing_waiver(), ObjectId("d" * 24))
 
     assert n == 2
-    assert mock_upsert.call_count == 2
+    mock_events.assert_called_once()
+    mock_fetch.assert_called_once()
+    mock_bulk.assert_called_once()
+    written = mock_bulk.call_args[0][0]
+    assert len(written) == 2
+    assert {u["status"] for u in written} == {"excused"}
+    assert mock_log.call_count == 2
+
+
+def test_distribute_standing_only_writes_absent_records():
+    cadet_id = ObjectId("b" * 24)
+    cadet = {"_id": cadet_id, "user_id": ObjectId("f" * 24)}
+    event_a = {"_id": ObjectId("c" * 24), "event_type": "pt"}
+    event_b = {"_id": ObjectId("d" * 24), "event_type": "lab"}
+    absent_record = {
+        "_id": ObjectId("1" * 24),
+        "cadet_id": cadet_id,
+        "event_id": event_a["_id"],
+        "status": "absent",
+    }
+    present_record = {
+        "_id": ObjectId("2" * 24),
+        "cadet_id": cadet_id,
+        "event_id": event_b["_id"],
+        "status": "present",
+    }
+
+    with (
+        patch("services.waivers.get_cadet_by_user_id", return_value=cadet),
+        patch(
+            "services.waivers.get_events_by_date_range",
+            return_value=[event_a, event_b],
+        ),
+        patch(
+            "services.waivers.get_attendance_records_for_cadet_in_events",
+            return_value=[absent_record, present_record],
+        ),
+        patch("services.waivers.bulk_upsert_attendance_status") as mock_bulk,
+        patch("services.waivers.log_attendance_modification"),
+    ):
+        n = distribute_excused_status(_standing_waiver(), ObjectId("d" * 24))
+
+    assert n == 1
+    written = mock_bulk.call_args[0][0]
+    assert len(written) == 1
+    assert written[0]["event_id"] == absent_record["event_id"]
 
 
 def test_distribute_standing_skips_records_already_present():
@@ -707,16 +791,16 @@ def test_distribute_standing_skips_records_already_present():
             return_value=[event],
         ),
         patch(
-            "services.waivers.get_attendance_record_by_event_cadet",
-            return_value=record,
+            "services.waivers.get_attendance_records_for_cadet_in_events",
+            return_value=[record],
         ),
-        patch("services.waivers.upsert_attendance_record") as mock_upsert,
+        patch("services.waivers.bulk_upsert_attendance_status") as mock_bulk,
         patch("services.waivers.log_attendance_modification"),
     ):
         n = distribute_excused_status(_standing_waiver(), ObjectId("d" * 24))
 
     assert n == 0
-    mock_upsert.assert_not_called()
+    mock_bulk.assert_not_called()
 
 
 def test_distribute_standing_returns_zero_when_no_cadet():
@@ -738,8 +822,11 @@ def test_distribute_standing_passes_event_types_filter():
         patch(
             "services.waivers.get_events_by_date_range", return_value=[]
         ) as mock_events,
-        patch("services.waivers.get_attendance_record_by_event_cadet"),
-        patch("services.waivers.upsert_attendance_record"),
+        patch(
+            "services.waivers.get_attendance_records_for_cadet_in_events",
+            return_value=[],
+        ),
+        patch("services.waivers.bulk_upsert_attendance_status"),
         patch("services.waivers.log_attendance_modification"),
     ):
         distribute_excused_status(

--- a/tests/test_waivers.py
+++ b/tests/test_waivers.py
@@ -1,13 +1,19 @@
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from unittest.mock import patch, MagicMock
 
+from bson import ObjectId
+
 from services.waivers import (
-    get_all_waivers_for_cadet,
+    apply_sickness_auto_approval,
+    compute_standing_waiver_dates,
+    distribute_excused_status,
     get_absent_records_without_waiver,
+    get_all_waivers_for_cadet,
     get_common_reasons,
     is_first_sickness_waiver,
-    apply_sickness_auto_approval,
     resubmit_auto_denied_waiver,
+    revert_excused_status,
+    validate_standing_waiver,
     withdraw_waiver,
 )
 
@@ -467,3 +473,337 @@ def test_apply_sickness_auto_approval_comment_mentions_auto():
         apply_sickness_auto_approval("w1", "user1")
         comments = mock_approval.call_args[1]["comments"]
         assert "auto" in comments.lower()
+
+
+# =============================================================================
+# compute_standing_waiver_dates / validate_standing_waiver
+# =============================================================================
+
+_PT_DAYS = ["Monday", "Tuesday", "Thursday"]
+_LLAB_DAYS = ["Friday"]
+_MON = date(2026, 4, 27)
+_FRI = date(2026, 5, 1)
+_SUN = date(2026, 5, 3)
+
+
+def _patched_event_config():
+    return patch(
+        "services.waivers.get_event_config",
+        return_value={"pt_days": _PT_DAYS, "llab_days": _LLAB_DAYS},
+    )
+
+
+def test_compute_standing_dates_default_event_types_returns_pt_and_llab():
+    with _patched_event_config():
+        result = compute_standing_waiver_dates(_MON, _SUN)
+    types = {r["type"] for r in result}
+    assert types == {"PT", "LLAB"}
+    assert len(result) == 4
+
+
+def test_compute_standing_dates_pt_only():
+    with _patched_event_config():
+        result = compute_standing_waiver_dates(_MON, _SUN, event_types=["pt"])
+    assert all(r["type"] == "PT" for r in result)
+    assert len(result) == 3
+
+
+def test_compute_standing_dates_lab_only():
+    with _patched_event_config():
+        result = compute_standing_waiver_dates(_MON, _SUN, event_types=["lab"])
+    assert all(r["type"] == "LLAB" for r in result)
+    assert len(result) == 1
+
+
+def test_validate_standing_rejects_end_before_start():
+    with _patched_event_config():
+        ok, why = validate_standing_waiver(_FRI, _MON)
+    assert ok is False
+    assert "End date" in why
+
+
+def test_validate_standing_rejects_cross_year():
+    with (
+        _patched_event_config(),
+        patch(
+            "services.waivers.datetime",
+            wraps=datetime,
+        ) as mock_dt,
+    ):
+        mock_dt.now.return_value = datetime(2026, 6, 1, tzinfo=timezone.utc)
+        ok, why = validate_standing_waiver(date(2025, 12, 1), date(2025, 12, 7))
+    assert ok is False
+    assert "current year" in why
+
+
+def test_validate_standing_rejects_empty_range_with_no_eligible_days():
+    with (
+        _patched_event_config(),
+        patch(
+            "services.waivers.datetime",
+            wraps=datetime,
+        ) as mock_dt,
+    ):
+        mock_dt.now.return_value = datetime(2026, 6, 1, tzinfo=timezone.utc)
+        ok, why = validate_standing_waiver(date(2026, 5, 2), date(2026, 5, 3))
+    assert ok is False
+    assert "PT" in why or "LLAB" in why
+
+
+def test_validate_standing_accepts_valid_range():
+    with (
+        _patched_event_config(),
+        patch(
+            "services.waivers.datetime",
+            wraps=datetime,
+        ) as mock_dt,
+    ):
+        mock_dt.now.return_value = datetime(2026, 6, 1, tzinfo=timezone.utc)
+        ok, why = validate_standing_waiver(_MON, _SUN)
+    assert ok is True
+    assert why == ""
+
+
+# =============================================================================
+# distribute_excused_status (singular waiver)
+# =============================================================================
+
+
+def test_distribute_singular_flips_absent_to_excused():
+    waiver = {
+        "_id": "w1",
+        "is_standing": False,
+        "attendance_record_id": ObjectId("a" * 24),
+    }
+    record = {
+        "_id": ObjectId("a" * 24),
+        "cadet_id": ObjectId("b" * 24),
+        "event_id": ObjectId("c" * 24),
+        "status": "absent",
+    }
+
+    with (
+        patch(
+            "services.waivers.get_attendance_record_by_id", return_value=record
+        ),
+        patch("services.waivers.upsert_attendance_record") as mock_upsert,
+        patch("services.waivers.log_attendance_modification") as mock_log,
+    ):
+        n = distribute_excused_status(waiver, ObjectId("d" * 24))
+
+    assert n == 1
+    assert mock_upsert.call_args.kwargs["status"] == "excused"
+    assert mock_log.call_args.kwargs["new_status"] == "excused"
+
+
+def test_distribute_singular_skips_present_record():
+    waiver = {
+        "_id": "w1",
+        "is_standing": False,
+        "attendance_record_id": ObjectId("a" * 24),
+    }
+    record = {
+        "_id": ObjectId("a" * 24),
+        "cadet_id": ObjectId("b" * 24),
+        "event_id": ObjectId("c" * 24),
+        "status": "present",
+    }
+
+    with (
+        patch(
+            "services.waivers.get_attendance_record_by_id", return_value=record
+        ),
+        patch("services.waivers.upsert_attendance_record") as mock_upsert,
+        patch("services.waivers.log_attendance_modification") as mock_log,
+    ):
+        n = distribute_excused_status(waiver, ObjectId("d" * 24))
+
+    assert n == 0
+    mock_upsert.assert_not_called()
+    mock_log.assert_not_called()
+
+
+def test_distribute_singular_returns_zero_when_record_missing():
+    waiver = {
+        "_id": "w1",
+        "is_standing": False,
+        "attendance_record_id": ObjectId("a" * 24),
+    }
+
+    with (
+        patch("services.waivers.get_attendance_record_by_id", return_value=None),
+        patch("services.waivers.upsert_attendance_record") as mock_upsert,
+    ):
+        n = distribute_excused_status(waiver, ObjectId("d" * 24))
+
+    assert n == 0
+    mock_upsert.assert_not_called()
+
+
+# =============================================================================
+# distribute_excused_status (standing waiver)
+# =============================================================================
+
+
+def _standing_waiver(event_types=None):
+    return {
+        "_id": ObjectId("e" * 24),
+        "is_standing": True,
+        "submitted_by_user_id": ObjectId("f" * 24),
+        "start_date": datetime(2026, 4, 27, tzinfo=timezone.utc),
+        "end_date": datetime(2026, 5, 3, 23, 59, 59, tzinfo=timezone.utc),
+        "event_types": event_types or ["pt", "lab"],
+    }
+
+
+def test_distribute_standing_excuses_all_absent_records_in_range():
+    cadet_id = ObjectId("b" * 24)
+    cadet = {"_id": cadet_id, "user_id": ObjectId("f" * 24)}
+    event_a = {"_id": ObjectId("c" * 24), "event_type": "pt"}
+    event_b = {"_id": ObjectId("d" * 24), "event_type": "lab"}
+    record_a = {
+        "_id": ObjectId("1" * 24),
+        "cadet_id": cadet_id,
+        "event_id": event_a["_id"],
+        "status": "absent",
+    }
+    record_b = {
+        "_id": ObjectId("2" * 24),
+        "cadet_id": cadet_id,
+        "event_id": event_b["_id"],
+        "status": "absent",
+    }
+
+    with (
+        patch("services.waivers.get_cadet_by_user_id", return_value=cadet),
+        patch(
+            "services.waivers.get_events_by_date_range",
+            return_value=[event_a, event_b],
+        ),
+        patch(
+            "services.waivers.get_attendance_record_by_event_cadet",
+            side_effect=[record_a, record_b],
+        ),
+        patch("services.waivers.upsert_attendance_record") as mock_upsert,
+        patch("services.waivers.log_attendance_modification"),
+    ):
+        n = distribute_excused_status(_standing_waiver(), ObjectId("d" * 24))
+
+    assert n == 2
+    assert mock_upsert.call_count == 2
+
+
+def test_distribute_standing_skips_records_already_present():
+    cadet_id = ObjectId("b" * 24)
+    cadet = {"_id": cadet_id, "user_id": ObjectId("f" * 24)}
+    event = {"_id": ObjectId("c" * 24), "event_type": "pt"}
+    record = {
+        "_id": ObjectId("1" * 24),
+        "cadet_id": cadet_id,
+        "event_id": event["_id"],
+        "status": "present",
+    }
+
+    with (
+        patch("services.waivers.get_cadet_by_user_id", return_value=cadet),
+        patch(
+            "services.waivers.get_events_by_date_range",
+            return_value=[event],
+        ),
+        patch(
+            "services.waivers.get_attendance_record_by_event_cadet",
+            return_value=record,
+        ),
+        patch("services.waivers.upsert_attendance_record") as mock_upsert,
+        patch("services.waivers.log_attendance_modification"),
+    ):
+        n = distribute_excused_status(_standing_waiver(), ObjectId("d" * 24))
+
+    assert n == 0
+    mock_upsert.assert_not_called()
+
+
+def test_distribute_standing_returns_zero_when_no_cadet():
+    with (
+        patch("services.waivers.get_cadet_by_user_id", return_value=None),
+        patch("services.waivers.get_events_by_date_range") as mock_events,
+    ):
+        n = distribute_excused_status(_standing_waiver(), ObjectId("d" * 24))
+
+    assert n == 0
+    mock_events.assert_not_called()
+
+
+def test_distribute_standing_passes_event_types_filter():
+    cadet = {"_id": ObjectId("b" * 24), "user_id": ObjectId("f" * 24)}
+
+    with (
+        patch("services.waivers.get_cadet_by_user_id", return_value=cadet),
+        patch(
+            "services.waivers.get_events_by_date_range", return_value=[]
+        ) as mock_events,
+        patch("services.waivers.get_attendance_record_by_event_cadet"),
+        patch("services.waivers.upsert_attendance_record"),
+        patch("services.waivers.log_attendance_modification"),
+    ):
+        distribute_excused_status(
+            _standing_waiver(event_types=["pt"]), ObjectId("d" * 24)
+        )
+
+    assert mock_events.call_args.kwargs["event_types"] == ["pt"]
+
+
+# =============================================================================
+# revert_excused_status
+# =============================================================================
+
+
+def test_revert_singular_flips_excused_back_to_absent():
+    waiver = {
+        "_id": "w1",
+        "is_standing": False,
+        "attendance_record_id": ObjectId("a" * 24),
+    }
+    record = {
+        "_id": ObjectId("a" * 24),
+        "cadet_id": ObjectId("b" * 24),
+        "event_id": ObjectId("c" * 24),
+        "status": "excused",
+    }
+
+    with (
+        patch(
+            "services.waivers.get_attendance_record_by_id", return_value=record
+        ),
+        patch("services.waivers.upsert_attendance_record") as mock_upsert,
+        patch("services.waivers.log_attendance_modification"),
+    ):
+        n = revert_excused_status(waiver, ObjectId("d" * 24))
+
+    assert n == 1
+    assert mock_upsert.call_args.kwargs["status"] == "absent"
+
+
+def test_revert_singular_leaves_present_alone():
+    waiver = {
+        "_id": "w1",
+        "is_standing": False,
+        "attendance_record_id": ObjectId("a" * 24),
+    }
+    record = {
+        "_id": ObjectId("a" * 24),
+        "cadet_id": ObjectId("b" * 24),
+        "event_id": ObjectId("c" * 24),
+        "status": "present",
+    }
+
+    with (
+        patch(
+            "services.waivers.get_attendance_record_by_id", return_value=record
+        ),
+        patch("services.waivers.upsert_attendance_record") as mock_upsert,
+    ):
+        n = revert_excused_status(waiver, ObjectId("d" * 24))
+
+    assert n == 0
+    mock_upsert.assert_not_called()

--- a/utils/create_indexes.py
+++ b/utils/create_indexes.py
@@ -21,6 +21,8 @@ def create_indexes() -> None:
     _drop_if_exists(db["events"], "archived")
     _drop_if_exists(db["events"], "start_date")
     _drop_if_exists(db["waivers"], "submitted_by_user_id")
+    _drop_if_exists(db["waivers"], "attendance_record_id_unique")
+    _drop_if_exists(db["waivers"], "attendance_record_id_active_unique")
 
     db["users"].create_indexes(
         [
@@ -83,7 +85,8 @@ def create_indexes() -> None:
                 name="attendance_record_id_active_unique",
                 unique=True,
                 partialFilterExpression={
-                    "status": {"$in": ["pending", "approved", "denied", "auto_denied"]}
+                    "attendance_record_id": {"$type": "objectId"},
+                    "status": {"$in": ["pending", "approved", "denied", "auto_denied"]},
                 },
             ),
             IndexModel(

--- a/utils/create_indexes.py
+++ b/utils/create_indexes.py
@@ -27,7 +27,14 @@ def create_indexes() -> None:
             IndexModel([("event_type", ASCENDING)], name="event_type"),
             IndexModel([("archived", ASCENDING)], name="archived"),
             IndexModel([("created_by_user_id", ASCENDING)], name="created_by_user_id"),
-            IndexModel([("start_date", ASCENDING)], name="start_date"),
+            IndexModel(
+                [
+                    ("archived", ASCENDING),
+                    ("event_type", ASCENDING),
+                    ("start_date", ASCENDING),
+                ],
+                name="archived_event_type_start_date",
+            ),
         ]
     )
 

--- a/utils/create_indexes.py
+++ b/utils/create_indexes.py
@@ -1,12 +1,26 @@
 from pymongo import ASCENDING, IndexModel
+from pymongo.errors import OperationFailure
 
 from utils.db import get_db
+
+
+def _drop_if_exists(collection, index_name: str) -> None:
+    try:
+        collection.drop_index(index_name)
+    except OperationFailure:
+        pass
 
 
 def create_indexes() -> None:
     db = get_db()
     if db is None:
         raise ConnectionError("Could not connect to MongoDB")
+
+    # Drop indexes superseded by compound replacements.
+    _drop_if_exists(db["events"], "event_type")
+    _drop_if_exists(db["events"], "archived")
+    _drop_if_exists(db["events"], "start_date")
+    _drop_if_exists(db["waivers"], "submitted_by_user_id")
 
     db["users"].create_indexes(
         [
@@ -24,8 +38,6 @@ def create_indexes() -> None:
 
     db["events"].create_indexes(
         [
-            IndexModel([("event_type", ASCENDING)], name="event_type"),
-            IndexModel([("archived", ASCENDING)], name="archived"),
             IndexModel([("created_by_user_id", ASCENDING)], name="created_by_user_id"),
             IndexModel(
                 [
@@ -75,7 +87,11 @@ def create_indexes() -> None:
                 },
             ),
             IndexModel(
-                [("submitted_by_user_id", ASCENDING)], name="submitted_by_user_id"
+                [
+                    ("submitted_by_user_id", ASCENDING),
+                    ("is_standing", ASCENDING),
+                ],
+                name="submitted_by_user_id_is_standing",
             ),
             IndexModel([("status", ASCENDING)], name="status"),
         ]

--- a/utils/date_range.py
+++ b/utils/date_range.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+from typing import Iterable
+
+
+def expand_event_dates(
+    start: date,
+    end: date,
+    pt_days: list[str],
+    llab_days: list[str],
+    skip: Iterable[date] | None = None,
+) -> list[dict]:
+    """Walk a date range and return event-eligible dates.
+
+    Each entry: {"date": date, "type": "PT"|"LLAB", "day": weekday name}.
+    Days that are neither PT nor LLAB, or that appear in `skip`, are omitted.
+    """
+    if end < start:
+        return []
+    skip_set = set(skip or [])
+    events: list[dict] = []
+    current = start
+    while current <= end:
+        day_name = current.strftime("%A")
+        if current not in skip_set:
+            if day_name in pt_days:
+                events.append({"date": current, "type": "PT", "day": day_name})
+            elif day_name in llab_days:
+                events.append({"date": current, "type": "LLAB", "day": day_name})
+        current += timedelta(days=1)
+    return events
+
+
+def parse_streamlit_date_range(
+    value: object,
+    default_start: date,
+    default_end: date,
+) -> tuple[date, date, bool]:
+    """Normalize the variable shape returned by st.date_input with a range value.
+
+    Streamlit can return: a tuple/list of 2, a tuple/list of 1 (mid-selection),
+    a single bare date, or None. Returns (start, end, is_complete).
+    `is_complete` is False when only one endpoint was selected.
+    """
+    if isinstance(value, (tuple, list)):
+        items = tuple(value)
+        if len(items) == 2:
+            start, end = items
+            if isinstance(start, date) and isinstance(end, date):
+                if start > end:
+                    start, end = end, start
+                return start, end, True
+        if len(items) == 1 and isinstance(items[0], date):
+            return items[0], default_end, False
+        return default_start, default_end, False
+
+    if isinstance(value, date):
+        return value, default_end, False
+
+    return default_start, default_end, False

--- a/utils/db_schema_crud.py
+++ b/utils/db_schema_crud.py
@@ -3,6 +3,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from bson import ObjectId
+from pymongo import UpdateOne
 from pymongo.results import DeleteResult, InsertOneResult, UpdateResult
 
 from utils.db import get_collection
@@ -458,6 +459,69 @@ def get_attendance_record_by_event_cadet(
             "cadet_id": ObjectId(cadet_id),
         }
     )
+
+
+def get_attendance_records_for_cadet_in_events(
+    event_ids: list[str | ObjectId],
+    cadet_id: str | ObjectId,
+) -> list[dict]:
+    """Bulk fetch attendance records for one cadet across many events.
+
+    Served by the `(event_id, cadet_id)` compound index on attendance_records.
+    """
+    col = get_collection("attendance_records")
+    if col is None or not event_ids:
+        return []
+    return list(
+        col.find(
+            {
+                "event_id": {"$in": [ObjectId(e_id) for e_id in event_ids]},
+                "cadet_id": ObjectId(cadet_id),
+            }
+        )
+    )
+
+
+def bulk_upsert_attendance_status(
+    updates: list[dict],
+) -> int:
+    """Apply many attendance status changes in a single round-trip.
+
+    Each update dict must contain: event_id, cadet_id, status,
+    recorded_by_user_id, and optionally recorded_by_roles. Returns the
+    number of upserted-or-modified documents.
+    """
+    col = get_collection("attendance_records")
+    if col is None or not updates:
+        return 0
+
+    now = datetime.now(timezone.utc)
+    ops: list[UpdateOne] = []
+    for u in updates:
+        set_doc: dict[str, Any] = {
+            "status": u["status"],
+            "recorded_by_user_id": ObjectId(u["recorded_by_user_id"]),
+            "updated_at": now,
+        }
+        roles = u.get("recorded_by_roles")
+        if roles is not None:
+            set_doc["recorded_by_roles"] = list(roles)
+        ops.append(
+            UpdateOne(
+                {
+                    "event_id": ObjectId(u["event_id"]),
+                    "cadet_id": ObjectId(u["cadet_id"]),
+                },
+                {
+                    "$set": set_doc,
+                    "$setOnInsert": {"created_at": now},
+                },
+                upsert=True,
+            )
+        )
+
+    result = col.bulk_write(ops, ordered=False)
+    return (result.modified_count or 0) + (result.upserted_count or 0)
 
 
 def upsert_attendance_record(

--- a/utils/db_schema_crud.py
+++ b/utils/db_schema_crud.py
@@ -305,6 +305,25 @@ def get_events_by_ids(event_ids: list[str | ObjectId]) -> list[dict]:
     return list(col.find({"_id": {"$in": object_ids}}))
 
 
+def get_events_by_date_range(
+    start: datetime,
+    end: datetime,
+    *,
+    event_types: list[str] | None = None,
+    include_archived: bool = False,
+) -> list[dict]:
+    """Return events whose start_date falls within [start, end] inclusive."""
+    col = get_collection("events")
+    if col is None:
+        return []
+    query: dict = {"start_date": {"$gte": start, "$lte": end}}
+    if event_types:
+        query["event_type"] = {"$in": list(event_types)}
+    if not include_archived:
+        query["archived"] = {"$ne": True}
+    return list(col.find(query))
+
+
 def update_event(event_id: str | ObjectId, updates: dict) -> UpdateResult | None:
     col = get_collection("events")
     if col is None:
@@ -571,27 +590,24 @@ def get_cadet_absence_stats() -> list[dict]:
 
 
 def create_waiver(
-    attendance_record_id: str | ObjectId,
+    attendance_record_id: str | ObjectId | None,
     reason: str,
     status: str,
     submitted_by_user_id: str | ObjectId,
     waiver_type: str = "non-medical",
     cadre_only: bool = False,
     attachments: list | None = None,
+    *,
+    is_standing: bool = False,
+    start_date: datetime | None = None,
+    end_date: datetime | None = None,
+    event_types: list[str] | None = None,
 ) -> InsertOneResult | None:
     col = get_collection("waivers")
     if col is None:
         return None
 
-    existing_withdrawn = col.find_one(
-        {
-            "attendance_record_id": ObjectId(attendance_record_id),
-            "status": "withdrawn",
-        }
-    )
-
     doc: dict = {
-        "attendance_record_id": ObjectId(attendance_record_id),
         "reason": reason,
         "status": status,
         "submitted_by_user_id": ObjectId(submitted_by_user_id),
@@ -601,12 +617,32 @@ def create_waiver(
         "created_at": datetime.now(timezone.utc),
     }
 
+    if is_standing:
+        doc["is_standing"] = True
+        doc["attendance_record_id"] = None
+        doc["start_date"] = start_date
+        doc["end_date"] = end_date
+        doc["event_types"] = list(event_types or ["pt", "lab"])
+        return col.insert_one(doc)
+
+    if attendance_record_id is None:
+        return None
+
+    attendance_oid = ObjectId(attendance_record_id)
+    existing_withdrawn = col.find_one(
+        {
+            "attendance_record_id": attendance_oid,
+            "status": "withdrawn",
+        }
+    )
+
+    doc["attendance_record_id"] = attendance_oid
     if existing_withdrawn:
         doc["previous_waiver_id"] = existing_withdrawn["_id"]
 
     result = col.insert_one(doc)
 
-    is_valid, why = validate_waiver(ObjectId(attendance_record_id))
+    is_valid, why = validate_waiver(attendance_oid)
     if not is_valid:
         col.update_one(
             {"_id": result.inserted_id},
@@ -667,6 +703,20 @@ def get_sickness_waivers_by_user(user_id: str | ObjectId) -> list[dict]:
                 "submitted_by_user_id": ObjectId(user_id),
                 "waiver_type": "sickness",
                 "status": {"$in": ["approved", "pending"]},
+            }
+        )
+    )
+
+
+def get_standing_waivers_by_user(user_id: str | ObjectId) -> list[dict]:
+    col = get_collection("waivers")
+    if col is None:
+        return []
+    return list(
+        col.find(
+            {
+                "submitted_by_user_id": ObjectId(user_id),
+                "is_standing": True,
             }
         )
     )


### PR DESCRIPTION
This PR adds support for standing waivers so cadets can submit a single waiver covering a date range and selected PT/LLAB event types. It also updates waiver approval logic to automatically mark covered absences as excused and revert them if an approved waiver is later denied, while introducing shared date-range utilities and expanding test coverage for standing waivers, attendance behavior, waiver review, and schedule/date parsing.

closes #18 
closes #19 